### PR TITLE
add track source type

### DIFF
--- a/app/_features/room/components/room-actions-bar.tsx
+++ b/app/_features/room/components/room-actions-bar.tsx
@@ -61,7 +61,7 @@ export default function RoomActionsBar({
         video: true,
       });
 
-      room.addStream(stream, 'local');
+      room.addLocalStream(stream, 'screen');
 
       for (const track of stream.getTracks()) {
         const sender = room.getPeerConnection()?.addTrack(track, stream);

--- a/app/_features/room/components/room-container.tsx
+++ b/app/_features/room/components/room-container.tsx
@@ -30,7 +30,7 @@ export default function RoomContainer({
           roomId: roomId,
           clientId: clientId,
           baseUrl: hubBaseURL,
-          media: new MediaManager(mediaStream),
+          media: new MediaManager(mediaStream, 'media'),
           event: new EventManager(),
         });
 
@@ -48,12 +48,14 @@ export default function RoomContainer({
       room.on(Room.PARTICIPANT_ADDED, (data) => {
         const stream: MediaStream = data.stream || {};
         const type: string = data.type;
+        const source: string = data.source;
 
         setStreams((prevState) => {
           const newStreams = Object.assign({}, prevState, {
             [stream.id]: {
               data: stream,
               type: type,
+              source: source,
             },
           });
 

--- a/app/_features/room/components/room-layout.tsx
+++ b/app/_features/room/components/room-layout.tsx
@@ -17,6 +17,7 @@ export default function RoomLayout({
     return {
       data: value.data,
       type: value.type,
+      source: value.source,
     };
   });
 
@@ -28,7 +29,7 @@ export default function RoomLayout({
               return (
                 <div
                   key={stream.data.id}
-                  className={`${styles['room-grid-screen']}`}
+                  className={`${stream.source} ${styles['room-grid-screen']}`}
                 >
                   <RoomScreen stream={stream} />
                 </div>

--- a/app/_features/room/modules/factory.ts
+++ b/app/_features/room/modules/factory.ts
@@ -15,6 +15,20 @@ type RegisterClientDataType = {
   client_id: string;
 };
 
+type TrackSource = {
+  track_id: string;
+  source: string;
+};
+
+export type TrackSources = TrackSource[];
+
+type SubscribeTrackRequestType = {
+  client_id: string;
+  stream_id: string;
+  track_id: string;
+};
+export type SubscribeTracksRequestType = SubscribeTrackRequestType[];
+
 const createRoomFactory = (fetcher: TypeFetch) => {
   return async (name = '') => {
     const response = await fetcher.post(`/rooms/create`, {
@@ -199,6 +213,56 @@ const terminateRoomFactory = (fetcher: TypeFetch) => {
   };
 };
 
+const setTrackSourcesFactory = (fetcher: TypeFetch) => {
+  return async (
+    roomId: string,
+    clientId: string,
+    trackSources: TrackSources
+  ) => {
+    const response = await fetcher.put(
+      `/rooms/${roomId}/settracksources/${clientId}`,
+      {
+        body: JSON.stringify(trackSources),
+      }
+    );
+
+    if (!response) {
+      throw new Error('Something went wrong. Please try again later!');
+    }
+
+    const result = {
+      code: parseInt(response.code, 10) || 500,
+    };
+
+    return result;
+  };
+};
+
+const subscribeTracksFactory = (fetcher: TypeFetch) => {
+  return async (
+    roomId: string,
+    clientId: string,
+    subscribeTracks: SubscribeTracksRequestType
+  ) => {
+    const response = await fetcher.post(
+      `/rooms/${roomId}/subscribetracks/${clientId}`,
+      {
+        body: JSON.stringify(subscribeTracks),
+      }
+    );
+
+    if (!response) {
+      throw new Error('Something went wrong. Please try again later!');
+    }
+
+    const result = {
+      code: parseInt(response.code, 10) || 500,
+    };
+
+    return result;
+  };
+};
+
 export const createRoom = createRoomFactory(fetcher);
 export const registerClient = registerClientFactory(fetcher);
 export const sendIceCandidate = sendIceCandidateFactory(fetcher);
@@ -207,3 +271,5 @@ export const allowRenegotation = allowRenegotationFactory(fetcher);
 export const joinRoom = joinRoomFactory(fetcher);
 export const leaveRoom = leaveRoomFactory(fetcher);
 export const terminateRoom = terminateRoomFactory(fetcher);
+export const setTrackSources = setTrackSourcesFactory(fetcher);
+export const subscribeTracks = subscribeTracksFactory(fetcher);

--- a/app/_features/room/modules/media.ts
+++ b/app/_features/room/modules/media.ts
@@ -1,15 +1,34 @@
 export type StreamsType = {
-  [key: string]: MediaStream;
+  [key: string]: MediaStreamType;
+};
+
+export type MediaStreamType = {
+  stream: MediaStream;
+  source: string;
+};
+
+export type AvailableStreamType = {
+  [key: string]: {
+    clientid: string;
+    streamid: string;
+    source: string;
+  };
 };
 
 export class MediaManager {
   #localStreams: StreamsType;
   #streams: StreamsType;
-  constructor(localStream: MediaStream) {
+  #availableStreams: AvailableStreamType;
+
+  constructor(localStream: MediaStream, source: string) {
     this.#localStreams = {};
     this.#streams = {};
+    this.#availableStreams = {};
 
-    this.#localStreams[localStream.id] = localStream;
+    this.#localStreams[localStream.id] = {
+      stream: localStream,
+      source,
+    };
   }
 
   static async getUserMedia(constraints: MediaStreamConstraints) {
@@ -38,9 +57,20 @@ export class MediaManager {
     return this.#streams;
   }
 
-  addLocalStream(stream: MediaStream) {
+  getStreamSource(streamId: string) {
+    return this.#streams[streamId].source;
+  }
+
+  getLocalStreamSource(streamId: string) {
+    return this.#localStreams[streamId].source;
+  }
+
+  addLocalStream(stream: MediaStream, source: string) {
     if (stream instanceof MediaStream) {
-      this.#localStreams[stream.id] = stream;
+      this.#localStreams[stream.id] = {
+        stream: stream,
+        source: source,
+      };
     }
   }
 
@@ -48,13 +78,26 @@ export class MediaManager {
     delete this.#localStreams[streamId];
   }
 
+  addAvailableStream(clientid: string, streamid: string, source: string) {
+    this.#availableStreams[streamid] = {
+      clientid: clientid,
+      streamid: streamid,
+      source: source,
+    };
+  }
+
   addStream(stream: MediaStream) {
     if (stream instanceof MediaStream) {
-      this.#streams[stream.id] = stream;
+      console.log(this.#availableStreams);
+      this.#streams[stream.id] = {
+        stream: stream,
+        source: this.#availableStreams[stream.id].source,
+      };
     }
   }
 
   removeStream(streamId: string) {
     delete this.#streams[streamId];
+    delete this.#availableStreams[streamId];
   }
 }

--- a/app/_features/room/types/types.d.ts
+++ b/app/_features/room/types/types.d.ts
@@ -13,6 +13,7 @@ type RoomLayoutProps = {
 type StreamStateType = {
   data: MediaStream;
   type: 'local' | 'remote';
+  source: string;
 };
 
 type RoomStreamsStateType = {


### PR DESCRIPTION
This update follows the latest update from inLive Hub API changes that change how clients publish and subscribe to the track to identify the track source, whether it is a media device or screen sharing. The video container will have a specific `media` or `screen` class name on their div container. This will differentiate and allow us to put the screen-sharing video on a bigger layout ratio when there is a screen-sharing video in the room.