### PR TITLE
fix: success auth redirect should be based on previous path

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,6 +1,6 @@
 # App
 NEXT_PUBLIC_APP_ENV=development
-NEXT_PUBLIC_APP_ORIGIN=https://room.inlive.app
+NEXT_PUBLIC_APP_ORIGIN=http://localhost:3000
 
 # Inlive Hub API
 NEXT_PUBLIC_INLIVE_HUB_ORIGIN=https://hub.inlive.app

--- a/app/(server)/api/auth/[provider]/authenticate/route.ts
+++ b/app/(server)/api/auth/[provider]/authenticate/route.ts
@@ -12,13 +12,16 @@ export async function GET(
   const codeParam = url.searchParams.get('code') || '';
   const stateParam = url.searchParams.get('state') || '';
   const stateCookie = request.cookies.get('state')?.value || '';
+  const pathnameCookie = request.cookies.get('pathname')?.value || '';
   const provider = params.provider;
 
   if (stateParam === stateCookie) {
     const authResponse = await authenticate(provider, currentPath, codeParam);
 
     if (authResponse.data.token) {
-      const response = NextResponse.redirect(APP_ORIGIN, { status: 307 });
+      const response = NextResponse.redirect(`${APP_ORIGIN}${pathnameCookie}`, {
+        status: 307,
+      });
 
       response.cookies.set({
         name: 'token',

--- a/app/(server)/api/auth/[provider]/authorize/route.ts
+++ b/app/(server)/api/auth/[provider]/authorize/route.ts
@@ -8,6 +8,7 @@ export async function POST(
   { params }: { params: { provider: string } }
 ) {
   const provider = params.provider;
+  const { pathname = '' } = await request.json();
   const state = crypto.randomUUID();
   const relativeRedirectUri = `/api/auth/${provider}/authenticate`;
   const absoluteRedirectUri = `${APP_ORIGIN}${relativeRedirectUri}`;
@@ -28,6 +29,15 @@ export async function POST(
     response.cookies.set({
       name: 'state',
       value: state,
+      path: relativeRedirectUri,
+      sameSite: 'lax',
+      maxAge: oneHour,
+      httpOnly: true,
+    });
+
+    response.cookies.set({
+      name: 'pathname',
+      value: pathname,
       path: relativeRedirectUri,
       sameSite: 'lax',
       maxAge: oneHour,

--- a/app/_shared/components/auth/sign-in-modal.tsx
+++ b/app/_shared/components/auth/sign-in-modal.tsx
@@ -39,7 +39,11 @@ export default function SignInModal() {
   const handleSignIn = async (provider: string) => {
     try {
       const response: AuthType.AuthorizeResponse =
-        await InternalApiFetcher.post(`/api/auth/${provider}/authorize`);
+        await InternalApiFetcher.post(`/api/auth/${provider}/authorize`, {
+          body: JSON.stringify({
+            pathname: window.location.pathname,
+          }),
+        });
 
       window.location.href = response.data;
     } catch (error) {


### PR DESCRIPTION
# Changelogs
- Fix successful auth redirect should be based on previous user path before user tries to authorize themselves
- `NEXT_PUBLIC_APP_ORIGIN` example use localhost by default