### PR TITLE
fix: device output selection

### DIFF
--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -94,7 +94,7 @@ export default function ButtonCamera() {
             selectedKeys={selectedVideoInputKey}
             onSelectionChange={onDeviceSelectionChange}
           >
-            <DropdownSection title="Select a camera" className="mb-0">
+            <DropdownSection title="Camera" className="mb-0">
               {selectVideoInputOptions.map((item, index) => {
                 return (
                   <DropdownItem

--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -106,7 +106,9 @@ export default function ButtonCamera() {
                         : 'Switch to this device'
                     }
                   >
-                    {item.label || `Camera ${index}`}
+                    {item.label === 'Default'
+                      ? 'Default Camera'
+                      : item.label || `Camera ${index}`}
                   </DropdownItem>
                 );
               })}

--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -108,7 +108,7 @@ export default function ButtonCamera() {
                   >
                     {item.label === 'Default'
                       ? 'Default Camera'
-                      : item.label || `Camera ${index}`}
+                      : item.label || `Camera ${index + 1}`}
                   </DropdownItem>
                 );
               })}

--- a/app/_features/room/components/button-microphone.tsx
+++ b/app/_features/room/components/button-microphone.tsx
@@ -43,6 +43,19 @@ export default function ButtonMicrophone() {
     onDeviceSelectionChange: onAudioOutputSelectionChange,
   } = useSelectDevice(audioOutputs, currentAudioOutput);
 
+  const speakerSelectionSupport = useMemo(() => {
+    if (typeof window === 'undefined') return false;
+
+    if (
+      AudioContext.prototype.hasOwnProperty('setSinkId') ||
+      HTMLMediaElement.prototype.hasOwnProperty('setSinkId')
+    ) {
+      return true;
+    }
+
+    return false;
+  }, []);
+
   const selectedDeviceKeys = useMemo(() => {
     return new Set([...selectedAudioInputKey, ...selectedAudioOutputKey]);
   }, [selectedAudioInputKey, selectedAudioOutputKey]);
@@ -79,19 +92,6 @@ export default function ButtonMicrophone() {
       didMount.current = true;
     }
   }, [active, peer]);
-
-  const speakerSelectionSupport = useMemo(() => {
-    if (typeof window === 'undefined') return false;
-
-    if (
-      AudioContext.prototype.hasOwnProperty('setSinkId') ||
-      HTMLMediaElement.prototype.hasOwnProperty('setSinkId')
-    ) {
-      return true;
-    }
-
-    return false;
-  }, []);
 
   return (
     <ButtonGroup variant="flat">
@@ -139,7 +139,9 @@ export default function ButtonMicrophone() {
                           : 'Switch to this device'
                       }
                     >
-                      {item.label || `Microphone ${index}`}
+                      {item.label === 'Default'
+                        ? 'Default Microphone'
+                        : item.label || `Microphone ${index + 1}`}
                     </DropdownItem>
                   );
                 })
@@ -162,7 +164,9 @@ export default function ButtonMicrophone() {
                           : 'Switch to this device'
                       }
                     >
-                      {item.label || `Speaker ${index}`}
+                      {item.label === 'Default'
+                        ? 'Default Speaker'
+                        : item.label || `Speaker ${index + 1}`}
                     </DropdownItem>
                   ))
                 ) : (
@@ -170,7 +174,10 @@ export default function ButtonMicrophone() {
                     key={`${currentAudioOutput?.kind}-${currentAudioOutput?.deviceId}`}
                     description="Currently in use"
                   >
-                    {currentAudioOutput?.label || 'Default Speaker'}
+                    {!currentAudioOutput?.label ||
+                    currentAudioOutput?.label === 'Default'
+                      ? 'Default Speaker'
+                      : currentAudioOutput?.label}
                   </DropdownItem>
                 )
               ) : (

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -73,7 +73,7 @@ export default function View({ pageId, roomId, origin }: ViewProps) {
     if (openConference) return;
 
     try {
-      const resumeAudioContextPromise = new Promise(async (resolve) => {
+      const resumeAudioContextPromise = new Promise<null>(async (resolve) => {
         if (AudioOutputContext && AudioOutputContext.state === 'suspended') {
           await AudioOutputContext.resume();
         }

--- a/app/_features/room/contexts/device-context.tsx
+++ b/app/_features/room/contexts/device-context.tsx
@@ -26,6 +26,9 @@ const DeviceContext = createContext({
   setCurrentActiveDevice: undefined as SetCurrentActiveDeviceType | undefined,
 });
 
+export const AudioOutputContext =
+  typeof window !== 'undefined' ? new AudioContext() : null;
+
 export const useDeviceContext = () => {
   return useContext(DeviceContext);
 };

--- a/app/_features/room/hooks/use-select-device.ts
+++ b/app/_features/room/hooks/use-select-device.ts
@@ -2,7 +2,10 @@ import { Selection } from '@nextui-org/react';
 import { useState, useMemo, Key, useCallback } from 'react';
 import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
-import { useDeviceContext } from '@/_features/room/contexts/device-context';
+import {
+  useDeviceContext,
+  AudioOutputContext,
+} from '@/_features/room/contexts/device-context';
 import { getUserMedia } from '@/_shared/utils/get-user-media';
 
 export const useSelectDevice = (
@@ -69,6 +72,20 @@ export const useSelectDevice = (
               setCurrentActiveDevice(currentSelectedDevice);
           }
         } else if (currentSelectedDevice.kind === 'audiooutput') {
+          if (
+            AudioContext.prototype.hasOwnProperty('setSinkId') &&
+            AudioOutputContext
+          ) {
+            const sinkId =
+              currentSelectedDevice.deviceId !== 'default'
+                ? currentSelectedDevice.deviceId
+                : '';
+
+            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+            //@ts-ignore
+            await AudioOutputContext.setSinkId(sinkId);
+          }
+
           setSelectedDeviceKeyState(selectedDeviceKeys);
           setCurrentActiveDevice &&
             setCurrentActiveDevice(currentSelectedDevice);

--- a/app/_features/room/hooks/use-video-screen.ts
+++ b/app/_features/room/hooks/use-video-screen.ts
@@ -35,10 +35,25 @@ export const useVideoScreen = (stream: ParticipantStream) => {
     }
 
     const play = async () => {
-      if (currentAudioOutput && 'setSinkId' in HTMLMediaElement.prototype) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        await video.setSinkId(currentAudioOutput.deviceId);
+      if (
+        currentAudioOutput &&
+        !AudioContext.prototype.hasOwnProperty('setSinkId')
+      ) {
+        const sinkId =
+          currentAudioOutput.deviceId !== 'default'
+            ? currentAudioOutput.deviceId
+            : '';
+
+        if (
+          HTMLMediaElement.prototype.hasOwnProperty('setSinkId') &&
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          sinkId !== video.sinkId
+        ) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          await video.setSinkId(sinkId);
+        }
       }
 
       video.srcObject = stream.mediaStream;


### PR DESCRIPTION
# Changelogs
- Fix the speaker selection doesn't get displayed on mobile device.
- When the user device doesn't support `setSinkId` method from [MediaElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/setSinkId) and [AudioContext](https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/setSinkId). The speaker selection only display the current speaker.
