### PR TITLE
fix: client-id should be unique per room-id

### DIFF
--- a/app/(server)/_features/participants/schema.ts
+++ b/app/(server)/_features/participants/schema.ts
@@ -1,12 +1,20 @@
-import { pgTable, text } from 'drizzle-orm/pg-core';
+import { pgTable, text, primaryKey } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 import { rooms } from '../room/schema';
 
-export const participants = pgTable('participants', {
-  clientID: text('id').notNull().primaryKey(),
-  name: text('name').notNull(),
-  roomID: text('room_id').references(() => rooms.id),
-});
+export const participants = pgTable(
+  'participants',
+  {
+    clientID: text('id').notNull(),
+    name: text('name').notNull(),
+    roomID: text('room_id').references(() => rooms.id),
+  },
+  (table) => {
+    return {
+      pk: primaryKey(table.clientID, table.roomID),
+    };
+  }
+);
 
 export const participantsRelations = relations(participants, ({ one }) => ({
   room: one(rooms, {

--- a/migrations/0004_client_id_unique-per-room.sql
+++ b/migrations/0004_client_id_unique-per-room.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "participants" DROP CONSTRAINT "participants_pkey";--> statement-breakpoint
+ALTER TABLE "participants" ADD CONSTRAINT "participants_id_room_id" PRIMARY KEY("id","room_id");

--- a/migrations/meta/0004_snapshot.json
+++ b/migrations/meta/0004_snapshot.json
@@ -1,0 +1,93 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "599f61c8-1839-429f-9c9c-a8c9e587548c",
+  "prevId": "219e1732-746f-4714-859a-f73d3ce50b52",
+  "tables": {
+    "participants": {
+      "name": "participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "room_id": {
+          "name": "room_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "participants_room_id_rooms_id_fk": {
+          "name": "participants_room_id_rooms_id_fk",
+          "tableFrom": "participants",
+          "tableTo": "rooms",
+          "columnsFrom": [
+            "room_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "participants_id_room_id": {
+          "name": "participants_id_room_id",
+          "columns": [
+            "id",
+            "room_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "rooms": {
+      "name": "rooms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1696500297795,
       "tag": "0003_remove_hub_id_from_room",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "5",
+      "when": 1696842709330,
+      "tag": "0004_client_id_unique-per-room",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
* Following inlive hub, client-id should be only unique per room-id
* participants table now uses composite primary key room_id and client_id