### PR TITLE
fix: improve mobile height style

### DIFF
--- a/app/_features/home/view/view.tsx
+++ b/app/_features/home/view/view.tsx
@@ -5,8 +5,8 @@ import Footer from '@/_shared/components/footer/footer';
 
 export default function View() {
   return (
-    <div className="flex flex-1 flex-col bg-zinc-900 text-zinc-200">
-      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-10 px-4">
+    <div className="min-viewport-height bg-zinc-900 text-zinc-200">
+      <div className="min-viewport-height mx-auto flex w-full max-w-5xl flex-1 flex-col gap-10 px-4">
         <Header />
         <main className="mx-auto flex flex-1 flex-col justify-center">
           <div className="flex w-full flex-col gap-20 lg:flex-row">

--- a/app/_features/room/components/chat-drawer-menu.tsx
+++ b/app/_features/room/components/chat-drawer-menu.tsx
@@ -79,7 +79,7 @@ export default function ChatDrawerMenu() {
       onClose={onMenuClosed}
       backdrop="transparent"
       scrollBehavior="inside"
-      className="fixed inset-y-0 right-0 h-full min-h-full w-full max-w-full bg-zinc-800/75 shadow-md backdrop-blur-md sm:w-96"
+      className="min-viewport-height fixed inset-y-0 right-0 w-full bg-zinc-800/75 shadow-md backdrop-blur-md sm:w-96"
     >
       <ModalContent>
         <ModalHeader className="border-b border-zinc-700 p-4">

--- a/app/_features/room/components/conference-actions-bar.tsx
+++ b/app/_features/room/components/conference-actions-bar.tsx
@@ -13,7 +13,7 @@ export default function ConferenceActionsBar() {
       <div className="flex h-full flex-col justify-center">
         <ButtonCamera />
       </div>
-      <div className="hidden h-full flex-col justify-center landscape:flex">
+      <div className="hidden h-full flex-col justify-center xl:landscape:flex">
         <ButtonScreenShare />
       </div>
       <div className="flex h-full flex-col justify-center">

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -26,7 +26,7 @@ export default function ConferenceScreen({
   return (
     <div className={`${styles['video-screen']} relative rounded-lg shadow-lg`}>
       {/* video screen overlay */}
-      <div className="absolute flex h-full w-full flex-col justify-end rounded-lg p-2">
+      <div className="absolute z-10 flex h-full w-full flex-col justify-end rounded-lg p-2">
         <div className="flex">
           <div
             className={`${styles['video-screen-name']} max-w-full truncate rounded bg-zinc-900/70 px-2 py-0.5 text-xs font-medium text-zinc-200 md:text-sm`}

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -2,8 +2,10 @@ import ConferenceParticipants from '@/_features/room/components/conference-parti
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';
 import styles from '@/_features/room/styles/conference.module.css';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
+import { useViewportHeight } from '@/_shared/hooks/use-viewport-height';
 
 export default function Conference() {
+  useViewportHeight();
   const { streams } = useParticipantContext();
 
   const hasScreen = (): boolean => {

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -2,10 +2,8 @@ import ConferenceParticipants from '@/_features/room/components/conference-parti
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';
 import styles from '@/_features/room/styles/conference.module.css';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
-import { useViewportHeight } from '@/_shared/hooks/use-viewport-height';
 
 export default function Conference() {
-  useViewportHeight();
   const { streams } = useParticipantContext();
 
   const hasScreen = (): boolean => {

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -2,8 +2,10 @@ import ConferenceParticipants from '@/_features/room/components/conference-parti
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';
 import styles from '@/_features/room/styles/conference.module.css';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
+import { useViewportHeight } from '@/_shared/hooks/use-viewport-height';
 
 export default function Conference() {
+  useViewportHeight();
   const { streams } = useParticipantContext();
 
   const hasScreen = (): boolean => {
@@ -22,7 +24,7 @@ export default function Conference() {
   };
 
   return (
-    <div className="h-screen w-screen">
+    <div className="viewport-height w-full">
       <div className={`${styles['participants']} ${getClass()}`}>
         <ConferenceParticipants />
       </div>

--- a/app/_features/room/components/lobby.tsx
+++ b/app/_features/room/components/lobby.tsx
@@ -130,8 +130,8 @@ export default function Lobby({ roomID }: LobbyProps) {
   return (
     <>
       <SetDisplayNameModal roomID={roomID} />
-      <div className="flex min-h-screen flex-col">
-        <div className="mx-auto flex w-full max-w-xl flex-1 flex-col gap-10 px-4">
+      <div className="min-viewport-height">
+        <div className="min-viewport-height mx-auto flex w-full max-w-xl flex-1 flex-col gap-10 px-4">
           <Header />
           <main className="flex flex-1 flex-col">
             <div className="flex flex-col gap-10">

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -11,6 +11,7 @@ import Conference from '@/_features/room/components/conference';
 import ChatDrawerMenu from '@/_features/room/components/chat-drawer-menu';
 import { useToggle } from '@/_shared/hooks/use-toggle';
 import type { ClientType } from '@/_shared/types/client';
+import { useViewportHeight } from '@/_shared/hooks/use-viewport-height';
 
 type ViewProps = {
   roomID: string;
@@ -18,6 +19,7 @@ type ViewProps = {
 };
 
 export default function View({ roomID, client }: ViewProps) {
+  useViewportHeight();
   const { active: isConferenceActive, setActive: setActiveConference } =
     useToggle(false);
 

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -33,7 +33,7 @@ export default function View({ roomID, client }: ViewProps) {
   }, [setActiveConference]);
 
   return (
-    <div className="flex flex-1 flex-col bg-zinc-900 text-zinc-200">
+    <div className="bg-zinc-900 text-zinc-200">
       <ClientProvider roomID={roomID} client={client}>
         <PeerProvider roomID={roomID} client={client}>
           <DeviceProvider>

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -11,7 +11,6 @@ import Conference from '@/_features/room/components/conference';
 import ChatDrawerMenu from '@/_features/room/components/chat-drawer-menu';
 import { useToggle } from '@/_shared/hooks/use-toggle';
 import type { ClientType } from '@/_shared/types/client';
-import { useViewportHeight } from '@/_shared/hooks/use-viewport-height';
 
 type ViewProps = {
   roomID: string;
@@ -19,7 +18,6 @@ type ViewProps = {
 };
 
 export default function View({ roomID, client }: ViewProps) {
-  useViewportHeight();
   const { active: isConferenceActive, setActive: setActiveConference } =
     useToggle(false);
 

--- a/app/_features/room/styles/conference.module.css
+++ b/app/_features/room/styles/conference.module.css
@@ -42,6 +42,10 @@
   }
 }
 
+.gallery .local video {
+  transform: scaleX(-1);
+}
+
 .media {
   min-height: 0;
   height: 100%;

--- a/app/_shared/components/containers/app-container.tsx
+++ b/app/_shared/components/containers/app-container.tsx
@@ -12,7 +12,7 @@ export default function AppContainer({
 }) {
   return (
     <>
-      <NextUIProvider className="flex flex-1 flex-col">
+      <NextUIProvider>
         <AuthProvider value={{ user: user }}>
           {children}
           <SignInModal />

--- a/app/_shared/components/errors/http-error.tsx
+++ b/app/_shared/components/errors/http-error.tsx
@@ -14,8 +14,8 @@ export default function HTTPError({
   description,
 }: HTTPErrorProps) {
   return (
-    <div className="flex min-h-screen flex-col bg-neutral-900 text-neutral-200">
-      <div className="mx-auto flex w-full max-w-5xl flex-1 flex-col gap-10 px-4">
+    <div className="min-viewport-height bg-neutral-900 text-neutral-200">
+      <div className="min-viewport-height mx-auto flex w-full max-w-5xl flex-1 flex-col gap-10 px-4">
         <Header />
         <main className="mx-auto flex flex-1 flex-col justify-center">
           <div className="flex items-center gap-5">

--- a/app/_shared/hooks/use-viewport-height.ts
+++ b/app/_shared/hooks/use-viewport-height.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+const useViewportHeight = () => {
+  useEffect(() => {
+    const setViewportHeight = () => {
+      const vh = window.innerHeight / 100;
+      document.documentElement.style.setProperty('--vh', `${vh}px`);
+    };
+
+    setViewportHeight();
+    window.addEventListener('orientationchange', setViewportHeight);
+
+    return () => {
+      window.removeEventListener('orientationchange', setViewportHeight);
+    };
+  }, []);
+};
+
+export { useViewportHeight };

--- a/app/_shared/styles/tailwind.css
+++ b/app/_shared/styles/tailwind.css
@@ -1,14 +1,24 @@
 @tailwind base;
 @tailwind components;
 
+:root {
+  --vh: 1vh;
+}
+
 /* To ensure the minimum height of body is 100% screen height */
 html, body {
-  min-height: 100%;
-  display: flex;
-  flex-direction: column;
-  flex: 1;
+  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
+}
 
-  @apply antialiased;
+.min-viewport-height {
+  min-height: 100vh;
+  min-height: calc(var(--vh, 1vh) * 100);
+}
+
+.viewport-height {
+  height: 100vh;
+  height: calc(var(--vh, 1vh) * 100);
 }
 
 @tailwind utilities;

--- a/app/_shared/styles/tailwind.css
+++ b/app/_shared/styles/tailwind.css
@@ -1,23 +1,16 @@
 @tailwind base;
 @tailwind components;
 
-:root {
-  --vh: 1vh;
-}
-
 /* To ensure the minimum height of body is 100% screen height */
 html, body {
-  min-height: 100vh;
   min-height: calc(var(--vh, 1vh) * 100);
 }
 
 .min-viewport-height {
-  min-height: 100vh;
   min-height: calc(var(--vh, 1vh) * 100);
 }
 
 .viewport-height {
-  height: 100vh;
   height: calc(var(--vh, 1vh) * 100);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,10 @@ export default function RootLayout({
         />
         <link rel="manifest" href="/images/favicon/manifest.webmanifest" />
       </head>
-      <body className={inter.className} suppressHydrationWarning={true}>
+      <body
+        className={`${inter.className} antialiased`}
+        suppressHydrationWarning={true}
+      >
         <Suspense fallback={null}>
           <MixpanelContainer />
         </Suspense>


### PR DESCRIPTION
## Changelogs:
- Every views use `min-viewport-height` class name to set default minimum height is same with minimum viewport
- For conference room view will use `viewport-height` and add little calculations to calculate the actual viewport height on mobile. This will ensure the mobile screen will always full height screen.
- Add mirroring style to local video
- Add z index to overlay to fix the participant name covered by the video element 