### PR TITLE
fix: handle when the user off the page window on mobile

### DIFF
--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback } from 'react';
+import { useCallback } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -15,14 +15,11 @@ import { useToggle } from '@/_shared/hooks/use-toggle';
 import { useDeviceContext } from '@/_features/room/contexts/device-context';
 import CameraOnIcon from '@/_shared/components/icons/camera-on-icon';
 import CameraOffIcon from '@/_shared/components/icons/camera-off-icon';
-import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import { useSelectDevice } from '@/_features/room/hooks/use-select-device';
 import ArrowDownFillIcon from '@/_shared/components/icons/arrow-down-fill-icon';
 
 export default function ButtonCamera() {
-  const { active, toggle } = useToggle(true);
-  const { peer } = usePeerContext();
-  const didMount = useRef(false);
+  const { active, setActive, setInActive } = useToggle(true);
   const { currentVideoInput, videoInputs, devices } = useDeviceContext();
 
   const {
@@ -48,19 +45,15 @@ export default function ButtonCamera() {
     [devices, onVideoInputSelectionChange]
   );
 
-  useEffect(() => {
-    if (!peer) return;
-
-    if (didMount.current) {
-      if (active) {
-        peer.turnOnCamera();
-      } else {
-        peer.turnOffCamera();
-      }
+  const handleClick = useCallback(() => {
+    if (active) {
+      setInActive();
+      document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
     } else {
-      didMount.current = true;
+      setActive();
+      document.dispatchEvent(new CustomEvent('trigger:turnon-camera'));
     }
-  }, [active, peer]);
+  }, [active, setActive, setInActive]);
 
   return (
     <ButtonGroup variant="flat">
@@ -69,7 +62,7 @@ export default function ButtonCamera() {
         variant="flat"
         aria-label="Toggle Video Camera"
         className="w-12 bg-zinc-700/70 hover:bg-zinc-600 active:bg-zinc-500"
-        onClick={toggle}
+        onClick={handleClick}
       >
         {active ? (
           <CameraOnIcon width={20} height={20} />

--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback } from 'react';
+import { useEffect, useCallback } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -47,13 +47,23 @@ export default function ButtonCamera() {
 
   const handleClick = useCallback(() => {
     if (active) {
-      setInActive();
       document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
     } else {
-      setActive();
       document.dispatchEvent(new CustomEvent('trigger:turnon-camera'));
     }
-  }, [active, setActive, setInActive]);
+  }, [active]);
+
+  useEffect(() => {
+    const onTurnOnCamera = () => setActive();
+    const onTurnOffCamera = () => setInActive();
+    document.addEventListener('trigger:turnon-camera', onTurnOnCamera);
+    document.addEventListener('trigger:turnoff-camera', onTurnOffCamera);
+
+    return () => {
+      document.removeEventListener('trigger:turnon-camera', onTurnOnCamera);
+      document.removeEventListener('trigger:turnoff-camera', onTurnOffCamera);
+    };
+  }, [setActive, setInActive]);
 
   return (
     <ButtonGroup variant="flat">

--- a/app/_features/room/components/button-microphone.tsx
+++ b/app/_features/room/components/button-microphone.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useMemo } from 'react';
+import { useEffect, useCallback, useMemo } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -78,13 +78,23 @@ export default function ButtonMicrophone() {
 
   const handleClick = useCallback(() => {
     if (active) {
-      setInActive();
       document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
     } else {
-      setActive();
       document.dispatchEvent(new CustomEvent('trigger:turnon-mic'));
     }
-  }, [active, setActive, setInActive]);
+  }, [active]);
+
+  useEffect(() => {
+    const onTurnOnMic = () => setActive();
+    const onTurnOffMic = () => setInActive();
+    document.addEventListener('trigger:turnon-mic', onTurnOnMic);
+    document.addEventListener('trigger:turnoff-mic', onTurnOffMic);
+
+    return () => {
+      document.removeEventListener('trigger:turnon-mic', onTurnOnMic);
+      document.removeEventListener('trigger:turnoff-mic', onTurnOffMic);
+    };
+  }, [setActive, setInActive]);
 
   return (
     <ButtonGroup variant="flat">

--- a/app/_features/room/components/button-microphone.tsx
+++ b/app/_features/room/components/button-microphone.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useCallback, useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -15,14 +15,11 @@ import { useToggle } from '@/_shared/hooks/use-toggle';
 import { useDeviceContext } from '@/_features/room/contexts/device-context';
 import MicrophoneOnIcon from '@/_shared/components/icons/microphone-on-icon';
 import MicrophoneOffIcon from '@/_shared/components/icons/microphone-off-icon';
-import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import { useSelectDevice } from '@/_features/room/hooks/use-select-device';
 import ArrowDownFillIcon from '@/_shared/components/icons/arrow-down-fill-icon';
 
 export default function ButtonMicrophone() {
-  const { active, toggle } = useToggle(true);
-  const { peer } = usePeerContext();
-  const didMount = useRef(false);
+  const { active, setActive, setInActive } = useToggle(true);
   const {
     currentAudioInput,
     currentAudioOutput,
@@ -79,19 +76,15 @@ export default function ButtonMicrophone() {
     [devices, onAudioInputSelectionChange, onAudioOutputSelectionChange]
   );
 
-  useEffect(() => {
-    if (!peer) return;
-
-    if (didMount.current) {
-      if (active) {
-        peer.turnOnMic();
-      } else {
-        peer.turnOffMic();
-      }
+  const handleClick = useCallback(() => {
+    if (active) {
+      setInActive();
+      document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
     } else {
-      didMount.current = true;
+      setActive();
+      document.dispatchEvent(new CustomEvent('trigger:turnon-mic'));
     }
-  }, [active, peer]);
+  }, [active, setActive, setInActive]);
 
   return (
     <ButtonGroup variant="flat">
@@ -100,7 +93,7 @@ export default function ButtonMicrophone() {
         variant="flat"
         aria-label="Toggle Microphone"
         className="w-12 bg-zinc-700/70 hover:bg-zinc-600 active:bg-zinc-500"
-        onClick={toggle}
+        onClick={handleClick}
       >
         {active ? (
           <MicrophoneOnIcon width={20} height={20} />

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { useEffect } from 'react';
 import { usePeerContext } from '@/_features/room/contexts/peer-context';
+import { useParticipantContext } from '@/_features/room/contexts/participant-context';
 import { hasTouchScreen } from '@/_shared/utils/has-touch-screen';
 
 export default function EventContainer({
@@ -9,24 +10,31 @@ export default function EventContainer({
   children: React.ReactNode;
 }) {
   const { peer } = usePeerContext();
+  const { streams } = useParticipantContext();
 
   useEffect(() => {
     if (!peer) return;
 
+    const localStream = streams.find(
+      (stream) => stream.origin === 'local' && stream.source === 'media'
+    );
+
+    if (!localStream) return;
+
     const onTurnOnCamera = () => {
-      if (peer) peer.turnOnCamera();
+      if (peer && localStream) peer.turnOnCamera();
     };
 
     const onTurnOffCamera = () => {
-      if (peer) peer.turnOffCamera();
+      if (peer && localStream) peer.turnOffCamera();
     };
 
     const onTurnOnMic = () => {
-      if (peer) peer.turnOnMic();
+      if (peer && localStream) peer.turnOnMic();
     };
 
     const onTurnOffMic = () => {
-      if (peer) peer.turnOffMic();
+      if (peer && localStream) peer.turnOffMic();
     };
 
     document.addEventListener('trigger:turnon-camera', onTurnOnCamera);
@@ -40,14 +48,13 @@ export default function EventContainer({
       document.removeEventListener('trigger:turnon-mic', onTurnOnMic);
       document.removeEventListener('trigger:turnoff-mic', onTurnOffMic);
     };
-  }, [peer]);
+  }, [peer, streams]);
 
   useEffect(() => {
     if (!peer) return;
+    const isTouchScreen = hasTouchScreen();
 
     const onVisibilityChange = () => {
-      const isTouchScreen = hasTouchScreen();
-
       if (document.visibilityState === 'hidden' && isTouchScreen && peer) {
         document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
         document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -11,6 +11,8 @@ export default function EventContainer({
   const { peer } = usePeerContext();
 
   useEffect(() => {
+    if (!peer) return;
+
     const onTurnOnCamera = () => {
       if (peer) peer.turnOnCamera();
     };
@@ -41,6 +43,8 @@ export default function EventContainer({
   }, [peer]);
 
   useEffect(() => {
+    if (!peer) return;
+
     const onVisibilityChange = () => {
       const isTouchScreen = hasTouchScreen();
 

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -1,0 +1,61 @@
+'use client';
+import { useEffect } from 'react';
+import { usePeerContext } from '@/_features/room/contexts/peer-context';
+import { hasTouchScreen } from '@/_shared/utils/has-touch-screen';
+
+export default function EventContainer({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { peer } = usePeerContext();
+
+  useEffect(() => {
+    const onTurnOnCamera = () => {
+      if (peer) peer.turnOnCamera();
+    };
+
+    const onTurnOffCamera = () => {
+      if (peer) peer.turnOffCamera();
+    };
+
+    const onTurnOnMic = () => {
+      if (peer) peer.turnOnMic();
+    };
+
+    const onTurnOffMic = () => {
+      if (peer) peer.turnOffMic();
+    };
+
+    document.addEventListener('trigger:turnon-camera', onTurnOnCamera);
+    document.addEventListener('trigger:turnoff-camera', onTurnOffCamera);
+    document.addEventListener('trigger:turnon-mic', onTurnOnMic);
+    document.addEventListener('trigger:turnoff-mic', onTurnOffMic);
+
+    return () => {
+      document.removeEventListener('trigger:turnon-camera', onTurnOnCamera);
+      document.removeEventListener('trigger:turnoff-camera', onTurnOffCamera);
+      document.removeEventListener('trigger:turnon-mic', onTurnOnMic);
+      document.removeEventListener('trigger:turnoff-mic', onTurnOffMic);
+    };
+  }, [peer]);
+
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      const isTouchScreen = hasTouchScreen();
+
+      if (document.visibilityState === 'hidden' && isTouchScreen && peer) {
+        document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
+        document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
+      }
+    };
+
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [peer]);
+
+  return <>{children}</>;
+}

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -52,19 +52,20 @@ export default function EventContainer({
 
   useEffect(() => {
     if (!peer) return;
+
     const isTouchScreen = hasTouchScreen();
 
-    const onVisibilityChange = () => {
-      if (document.visibilityState === 'hidden' && isTouchScreen && peer) {
+    const onWindowBlur = () => {
+      if (isTouchScreen && peer) {
         document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
         document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
       }
     };
 
-    document.addEventListener('visibilitychange', onVisibilityChange);
+    window.addEventListener('blur', onWindowBlur);
 
     return () => {
-      document.removeEventListener('visibilitychange', onVisibilityChange);
+      window.removeEventListener('blur', onWindowBlur);
     };
   }, [peer]);
 

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -4,11 +4,7 @@ import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
 import { hasTouchScreen } from '@/_shared/utils/has-touch-screen';
 
-export default function EventContainer({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function EventContainer() {
   const { peer } = usePeerContext();
   const { streams } = useParticipantContext();
 
@@ -69,5 +65,5 @@ export default function EventContainer({
     };
   }, [peer]);
 
-  return <>{children}</>;
+  return <></>;
 }

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -7,6 +7,7 @@ import { PeerProvider } from '@/_features/room/contexts/peer-context';
 import { DeviceProvider } from '@/_features/room/contexts/device-context';
 import { ParticipantProvider } from '@/_features/room/contexts/participant-context';
 import { ChatProvider } from '@/_features/room/contexts/chat-context';
+import EventContainer from '@/_features/room/components/event-container';
 import Conference from '@/_features/room/components/conference';
 import ChatDrawerMenu from '@/_features/room/components/chat-drawer-menu';
 import { useToggle } from '@/_shared/hooks/use-toggle';
@@ -39,12 +40,14 @@ export default function View({ roomID, client }: ViewProps) {
           <DeviceProvider>
             <ParticipantProvider>
               <ChatProvider>
-                <ChatDrawerMenu />
-                {isConferenceActive ? (
-                  <Conference />
-                ) : (
-                  <Lobby roomID={roomID} />
-                )}
+                <EventContainer roomID={roomID}>
+                  <ChatDrawerMenu />
+                  {isConferenceActive ? (
+                    <Conference />
+                  ) : (
+                    <Lobby roomID={roomID} />
+                  )}
+                </EventContainer>
               </ChatProvider>
             </ParticipantProvider>
           </DeviceProvider>

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -40,14 +40,13 @@ export default function View({ roomID, client }: ViewProps) {
           <DeviceProvider>
             <ParticipantProvider>
               <ChatProvider>
-                <EventContainer>
-                  <ChatDrawerMenu />
-                  {isConferenceActive ? (
-                    <Conference />
-                  ) : (
-                    <Lobby roomID={roomID} />
-                  )}
-                </EventContainer>
+                <EventContainer />
+                <ChatDrawerMenu />
+                {isConferenceActive ? (
+                  <Conference />
+                ) : (
+                  <Lobby roomID={roomID} />
+                )}
               </ChatProvider>
             </ParticipantProvider>
           </DeviceProvider>

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -40,7 +40,7 @@ export default function View({ roomID, client }: ViewProps) {
           <DeviceProvider>
             <ParticipantProvider>
               <ChatProvider>
-                <EventContainer roomID={roomID}>
+                <EventContainer>
                   <ChatDrawerMenu />
                   {isConferenceActive ? (
                     <Conference />

--- a/app/_shared/utils/has-touch-screen.ts
+++ b/app/_shared/utils/has-touch-screen.ts
@@ -1,0 +1,23 @@
+export const hasTouchScreen = () => {
+  let hasTouchScreen = false;
+
+  if ('maxTouchPoints' in navigator) {
+    hasTouchScreen = navigator.maxTouchPoints > 0;
+  } else if ('msMaxTouchPoints' in navigator) {
+    hasTouchScreen = navigator['msMaxTouchPoints'] > 0;
+  } else {
+    const mediaQuery = matchMedia?.('(pointer:coarse)');
+    if (mediaQuery?.media === '(pointer:coarse)') {
+      hasTouchScreen = !!mediaQuery.matches;
+    } else if ('orientation' in window) {
+      hasTouchScreen = true; // deprecated, but good fallback
+    } else {
+      const UA = navigator['userAgent'];
+      hasTouchScreen =
+        /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA) ||
+        /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA);
+    }
+  }
+
+  return hasTouchScreen;
+};


### PR DESCRIPTION
# Description
This PR will adjust the behavior when the user off the page window on mobile. On mobile, when the user off the page, the webrtc will not stream the video and audio tracks to the remote users. This makes the video on remote users will be freezed. One way to handle this is to make the user camera and audio tracks auto muted when the user off the page window on mobile.

I thought we could achieve this by listening the [visibilitychange](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event) event and checked if the [visibilityState](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState) was hidden. However, I didn't understand why the callback for visibilitychange `hidden` only called when the document had been active again, the callback didn't automatically run when the visibility is hidden. This made us couldn't use this event, at least until we understand more about this event.

Another way to listen when the user off the page window is by listening the [blur event](https://developer.mozilla.org/en-US/docs/Web/API/Window/blur_event). I think, this approach is currently suitable in our use case as a replacement for `visibilitychange` event.