### PR TITLE
refactor: leave room

### DIFF
--- a/app/_features/room/hooks/use-leave-room.ts
+++ b/app/_features/room/hooks/use-leave-room.ts
@@ -17,17 +17,11 @@ export const useLeaveRoom = () => {
 
       try {
         peer.disconnect();
-        await room
-          .leaveRoom(roomID, clientID, true)
-          .then((response) => {
-            if (!response) throw new Error('Failed to end the call');
-            if (response.code >= 300) {
-              console.error('Failed to end the call');
-            }
-          })
-          .catch((error) => {
-            throw error;
-          });
+        const response = await room.leaveRoom(roomID, clientID, false);
+
+        if (response.code >= 300) {
+          console.error('Failed to end the call');
+        }
 
         peer.setAsLeftRoom();
 

--- a/app/_shared/sdk/room/api/api.ts
+++ b/app/_shared/sdk/room/api/api.ts
@@ -292,20 +292,25 @@ export const createApi = ({ fetcher }: RoomAPIType.ApiDependencies) => {
       return result;
     };
 
-    leaveRoom = async (
-      roomId: string,
-      clientId: string,
-      useBeacon: boolean
-    ) => {
+    leaveRoom = async (roomId: string, clientId: string, useBeacon = false) => {
       if (!roomId || !clientId) {
         throw new Error('Room ID, and client ID are required');
       }
 
       const endpoint = `/rooms/${roomId}/leave/${clientId}`;
-      if (useBeacon) {
-        navigator.sendBeacon(`${this._fetcher.getBaseUrl()}${endpoint}`);
 
-        return;
+      if (useBeacon) {
+        const response = navigator.sendBeacon(
+          `${this._fetcher.getBaseUrl()}${endpoint}`
+        );
+
+        const result = {
+          code: response ? 200 : 500,
+          ok: response,
+          data: null,
+        };
+
+        return result;
       }
 
       const response: RoomAPIType.BaseResponseBody = await this._fetcher.delete(


### PR DESCRIPTION
## Changelogs
- Update leave room SDK and return the same response object when either using sendBeacon or regular fetch
- Refactor the useLeaveRoom function. The leaveRoom method will not be called useBeacon and use regular fetch instead 