### PR TITLE
feat: use max age for cookie

### DIFF
--- a/app/(server)/api/auth/[provider]/authenticate/route.ts
+++ b/app/(server)/api/auth/[provider]/authenticate/route.ts
@@ -23,7 +23,7 @@ export async function GET(
         status: 307,
       });
 
-      const sevenDays = 60 * 60 * 24 * 7;
+      const thirtyDays = 60 * 60 * 24 * 30;
 
       response.cookies.set({
         name: 'token',
@@ -31,7 +31,7 @@ export async function GET(
         path: '/',
         sameSite: 'lax',
         httpOnly: true,
-        maxAge: sevenDays,
+        maxAge: thirtyDays,
       });
 
       return response;

--- a/app/(server)/api/auth/[provider]/authenticate/route.ts
+++ b/app/(server)/api/auth/[provider]/authenticate/route.ts
@@ -23,12 +23,15 @@ export async function GET(
         status: 307,
       });
 
+      const sevenDays = 1000 * 60 * 60 * 24 * 7;
+
       response.cookies.set({
         name: 'token',
         value: authResponse.data.token,
         path: '/',
         sameSite: 'lax',
         httpOnly: true,
+        maxAge: sevenDays,
       });
 
       return response;

--- a/app/(server)/api/auth/[provider]/authenticate/route.ts
+++ b/app/(server)/api/auth/[provider]/authenticate/route.ts
@@ -23,7 +23,7 @@ export async function GET(
         status: 307,
       });
 
-      const sevenDays = 1000 * 60 * 60 * 24 * 7;
+      const sevenDays = 60 * 60 * 24 * 7;
 
       response.cookies.set({
         name: 'token',

--- a/app/(server)/api/room/[roomID]/setname/[clientID]/route.ts
+++ b/app/(server)/api/room/[roomID]/setname/[clientID]/route.ts
@@ -48,7 +48,7 @@ export async function PUT(
       { status: 200 }
     );
 
-    const thirtyDays = 1000 * 60 * 60 * 24 * 30;
+    const thirtyDays = 60 * 60 * 24 * 30;
 
     routeResponse.cookies.set({
       name: 'client_name',

--- a/app/(server)/api/room/[roomID]/setname/[clientID]/route.ts
+++ b/app/(server)/api/room/[roomID]/setname/[clientID]/route.ts
@@ -48,11 +48,14 @@ export async function PUT(
       { status: 200 }
     );
 
+    const thirtyDays = 1000 * 60 * 60 * 24 * 30;
+
     routeResponse.cookies.set({
       name: 'client_name',
       value: setNameResponse.name || clientName,
       path: pathname,
       sameSite: 'lax',
+      maxAge: thirtyDays,
     });
 
     return routeResponse;


### PR DESCRIPTION
## Changelogs
- token and client name cookies are set to expire after 30 days