### PR TITLE
feat: meeting and webinar layouts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": false,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 }

--- a/app/(pages)/room/[roomID]/page.tsx
+++ b/app/(pages)/room/[roomID]/page.tsx
@@ -46,31 +46,26 @@ export default async function Page() {
   const isModerator = roomData.createdBy === userAuth?.id;
 
   if (isModerator) {
-    const hostMetaData = await clientSDK.getMetadata(roomData.id, 'host');
-    const hostIDs = hostMetaData?.data?.host?.clientIDs;
+    const moderatorMeta = await clientSDK.getMetadata(roomData.id, 'moderator');
+    const moderatorIDs = moderatorMeta?.data?.moderatorIDs;
 
-    if (Array.isArray(hostIDs)) {
+    if (Array.isArray(moderatorIDs)) {
       await clientSDK.setMetadata(roomData.id, {
-        host: {
-          clientIDs: [...hostIDs, userClient.clientID],
-        },
+        moderatorIDs: [...moderatorIDs, userClient.clientID],
       });
     } else {
       await clientSDK.setMetadata(roomData.id, {
-        host: {
-          clientIDs: [userClient.clientID],
-        },
+        moderatorIDs: [userClient.clientID],
       });
     }
   }
 
+  // TODO: change room type dynamically based on roomData.type
+  const roomType = 'meeting';
+
   return (
     <AppContainer user={userAuth}>
-      <View
-        roomID={roomData.id}
-        client={userClient}
-        isModerator={isModerator}
-      />
+      <View roomID={roomData.id} client={userClient} roomType={roomType} />
     </AppContainer>
   );
 }

--- a/app/(server)/_shared/auth/auth.ts
+++ b/app/(server)/_shared/auth/auth.ts
@@ -15,6 +15,7 @@ export const createAuth = (fetcher: typeof InliveApiFetcher) => {
           headers: {
             Authorization: `Bearer ${token}`,
           },
+          cache: 'no-cache',
         });
 
       const data = response.data || {};

--- a/app/_features/room/components/button-leave.tsx
+++ b/app/_features/room/components/button-leave.tsx
@@ -13,12 +13,14 @@ import HangUpIcon from '@/_shared/components/icons/hang-up-icon';
 import { useClientContext } from '@/_features/room/contexts/client-context';
 import { useDataChannelContext } from '@/_features/room/contexts/datachannel-context';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
+import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 import ArrowDownFillIcon from '@/_shared/components/icons/arrow-down-fill-icon';
 
-export default function ButtonLeave({ isModerator }: { isModerator: boolean }) {
+export default function ButtonLeave() {
   const { clientID } = useClientContext();
   const { datachannels } = useDataChannelContext();
   const { streams } = useParticipantContext();
+  const { isModerator } = useMetadataContext();
 
   const handleLeaveRoom = () => {
     document.dispatchEvent(

--- a/app/_features/room/components/button-microphone.tsx
+++ b/app/_features/room/components/button-microphone.tsx
@@ -13,8 +13,6 @@ import {
 import type { Selection } from '@nextui-org/react';
 import { useToggle } from '@/_shared/hooks/use-toggle';
 import { useDeviceContext } from '@/_features/room/contexts/device-context';
-import { useClientContext } from '@/_features/room/contexts/client-context';
-import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 import MicrophoneOnIcon from '@/_shared/components/icons/microphone-on-icon';
 import MicrophoneOffIcon from '@/_shared/components/icons/microphone-off-icon';
 import { useSelectDevice } from '@/_features/room/hooks/use-select-device';
@@ -29,13 +27,6 @@ export default function ButtonMicrophone() {
     audioOutputs,
     devices,
   } = useDeviceContext();
-
-  const { clientID } = useClientContext();
-  const { host, speakers } = useMetadataContext();
-
-  const isSpeaker = useMemo(() => {
-    return speakers.includes(clientID) || host.clientIDs.includes(clientID);
-  }, [speakers, host, clientID]);
 
   const {
     selectedDeviceKey: selectedAudioInputKey,
@@ -86,14 +77,12 @@ export default function ButtonMicrophone() {
   );
 
   const handleClick = useCallback(() => {
-    if (!isSpeaker) return;
-
     if (active) {
       document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
     } else {
       document.dispatchEvent(new CustomEvent('trigger:turnon-mic'));
     }
-  }, [active, isSpeaker]);
+  }, [active]);
 
   useEffect(() => {
     const onTurnOnMic = () => setActive();
@@ -108,15 +97,8 @@ export default function ButtonMicrophone() {
   }, [setActive, setInActive]);
 
   return (
-    <ButtonGroup
-      variant="flat"
-      isDisabled={!isSpeaker}
-      aria-disabled={!isSpeaker}
-    >
+    <ButtonGroup variant="flat">
       <Button
-        isDisabled={!isSpeaker}
-        disabled={!isSpeaker}
-        aria-disabled={!isSpeaker}
         isIconOnly
         variant="flat"
         aria-label="Toggle Microphone"

--- a/app/_features/room/components/button-screen-share.tsx
+++ b/app/_features/room/components/button-screen-share.tsx
@@ -1,30 +1,18 @@
 'use client';
 
-import { useMemo } from 'react';
 import { Button } from '@nextui-org/react';
 import ScreenShareOnIcon from '@/_shared/components/icons/screen-share-on-icon';
 import ScreenShareOffIcon from '@/_shared/components/icons/screen-share-off-icon';
 import { useScreenShare } from '@/_features/room/hooks/use-screen-share';
-import { useClientContext } from '@/_features/room/contexts/client-context';
-import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 
 export default function ButtonScreenShare() {
   const { startScreenCapture, stopScreenCapture, screenCaptureActive } =
     useScreenShare();
 
-  const { clientID } = useClientContext();
-  const { host, speakers } = useMetadataContext();
-
-  const isSpeaker = useMemo(() => {
-    return speakers.includes(clientID) || host.clientIDs.includes(clientID);
-  }, [speakers, host, clientID]);
-
   const screenShareHandler = async (
     event: React.MouseEvent<HTMLButtonElement>
   ) => {
     event.preventDefault();
-
-    if (!isSpeaker) return;
 
     try {
       if (screenCaptureActive) {
@@ -45,9 +33,6 @@ export default function ButtonScreenShare() {
       aria-label={`Toggle screen share ${screenCaptureActive ? 'off' : 'on'}`}
       className="bg-zinc-700/70 hover:bg-zinc-600 active:bg-zinc-500"
       onClick={screenShareHandler}
-      isDisabled={!isSpeaker}
-      disabled={!isSpeaker}
-      aria-disabled={!isSpeaker}
     >
       {screenCaptureActive ? (
         <ScreenShareOffIcon width={20} height={20} />

--- a/app/_features/room/components/conference-actions-bar.tsx
+++ b/app/_features/room/components/conference-actions-bar.tsx
@@ -8,11 +8,7 @@ import ButtonScreenShare from '@/_features/room/components/button-screen-share';
 import ButtonChat from '@/_features/room/components/button-chat';
 import { hasTouchScreen } from '@/_shared/utils/has-touch-screen';
 
-export default function ConferenceActionsBar({
-  isModerator,
-}: {
-  isModerator: boolean;
-}) {
+export default function ConferenceActionsBar() {
   const [isTouchScreen, setIsTouchScreen] = useState(true);
 
   useEffect(() => {
@@ -39,7 +35,7 @@ export default function ConferenceActionsBar({
           <ButtonChat />
         </div>
         <div className="flex h-full flex-col justify-center">
-          <ButtonLeave isModerator={isModerator} />
+          <ButtonLeave />
         </div>
       </div>
     </div>

--- a/app/_features/room/components/conference-presentation-layout.tsx
+++ b/app/_features/room/components/conference-presentation-layout.tsx
@@ -46,10 +46,10 @@ export default function ConferencePresentationLayout({
       </div>
       <div className="speaker-container">
         <div className="speaker-grid">
-          {slicedSpeakers.map((speaker, index) => {
+          {slicedSpeakers.map((speaker) => {
             return (
               <div
-                key={`speaker${index}`}
+                key={`speaker-${speaker.id}`}
                 className="speaker-grid-item relative"
               >
                 <ConferenceScreen stream={speaker} />

--- a/app/_features/room/components/conference-presentation-layout.tsx
+++ b/app/_features/room/components/conference-presentation-layout.tsx
@@ -5,25 +5,22 @@ import '../styles/conference-presentation.css';
 import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 
 export default function ConferencePresentationLayout({
-  isModerator,
   streams,
 }: {
-  isModerator: boolean;
   streams: ParticipantStream[];
 }) {
-  const { host, speakers: speakerClientIDs } = useMetadataContext();
+  const { moderatorIDs, speakers: speakerClientIDs } = useMetadataContext();
   const MAX_VISIBLE_SPEAKERS = 8;
 
   const speakers = useMemo(() => {
     return streams.filter((stream) => {
       return (
-        (host.clientIDs.includes(stream.clientId) &&
-          stream.source === 'media') ||
+        (moderatorIDs.includes(stream.clientId) && stream.source === 'media') ||
         (speakerClientIDs.includes(stream.clientId) &&
           stream.source === 'media')
       );
     });
-  }, [streams, host, speakerClientIDs]);
+  }, [streams, moderatorIDs, speakerClientIDs]);
 
   const screens = useMemo(() => {
     return streams.filter((stream) => {
@@ -44,9 +41,7 @@ export default function ConferencePresentationLayout({
     <div className="conference-layout presentation">
       <div className="presentation-container">
         <div className="relative h-full w-full">
-          {latestScreen && (
-            <ConferenceScreen isModerator={isModerator} stream={latestScreen} />
-          )}
+          {latestScreen && <ConferenceScreen stream={latestScreen} />}
         </div>
       </div>
       <div className="speaker-container">
@@ -57,7 +52,7 @@ export default function ConferencePresentationLayout({
                 key={`speaker${index}`}
                 className="speaker-grid-item relative"
               >
-                <ConferenceScreen isModerator={isModerator} stream={speaker} />
+                <ConferenceScreen stream={speaker} />
               </div>
             );
           })}

--- a/app/_features/room/components/conference-presentation-layout.tsx
+++ b/app/_features/room/components/conference-presentation-layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 import ConferenceScreen from '@/_features/room/components/conference-screen';
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';

--- a/app/_features/room/components/conference-screen-hidden.tsx
+++ b/app/_features/room/components/conference-screen-hidden.tsx
@@ -40,7 +40,7 @@ export default function ConferenceScreenHidden({
       }
 
       audioRef.current.srcObject = stream.mediaStream;
-      audioRef.current.muted = false;
+      audioRef.current.muted = stream.origin === 'local';
       audioRef.current.autoplay = true;
     };
 

--- a/app/_features/room/components/conference-screen-hidden.tsx
+++ b/app/_features/room/components/conference-screen-hidden.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import type { ParticipantStream } from '@/_features/room/contexts/participant-context';
+import { useDeviceContext } from '@/_features/room/contexts/device-context';
+
+export default function ConferenceScreenHidden({
+  stream,
+}: {
+  stream: ParticipantStream;
+}) {
+  const audioRef = useRef<HTMLAudioElement>(null);
+  const { currentAudioOutput } = useDeviceContext();
+
+  useEffect(() => {
+    const play = async () => {
+      if (!audioRef.current) {
+        return;
+      }
+
+      if (
+        currentAudioOutput &&
+        !AudioContext.prototype.hasOwnProperty('setSinkId')
+      ) {
+        const sinkId =
+          currentAudioOutput.deviceId !== 'default'
+            ? currentAudioOutput.deviceId
+            : '';
+
+        if (
+          HTMLMediaElement.prototype.hasOwnProperty('setSinkId') &&
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          sinkId !== audioRef.current.sinkId
+        ) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          //@ts-ignore
+          await audioRef.current.setSinkId(sinkId);
+        }
+      }
+
+      audioRef.current.srcObject = stream.mediaStream;
+      audioRef.current.muted = false;
+      audioRef.current.autoplay = true;
+    };
+
+    play();
+  }, [currentAudioOutput, stream.mediaStream, stream.origin]);
+
+  return (
+    <audio
+      ref={audioRef}
+      className="absolute right-[99999px] h-0 w-0 opacity-0"
+    ></audio>
+  );
+}

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -203,6 +203,9 @@ export default function ConferenceScreen({
       <video
         className="absolute left-0 top-0 h-full w-full rounded-lg object-center"
         ref={videoRef}
+        style={{
+          transform: localVideoScreen ? 'scaleX(-1)' : 'scaleX(1)',
+        }}
       ></video>
     </div>
   );

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -20,10 +20,8 @@ import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 
 export default function ConferenceScreen({
   stream,
-  isModerator,
 }: {
   stream: ParticipantStream;
-  isModerator: boolean;
 }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const { currentAudioOutput } = useDeviceContext();
@@ -47,11 +45,11 @@ export default function ConferenceScreen({
           HTMLMediaElement.prototype.hasOwnProperty('setSinkId') &&
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           //@ts-ignore
-          sinkId !== video.sinkId
+          sinkId !== videoRef.current.sinkId
         ) {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           //@ts-ignore
-          await video.setSinkId(sinkId);
+          await videoRef.current.setSinkId(sinkId);
         }
       }
 
@@ -67,9 +65,9 @@ export default function ConferenceScreen({
   const { peer } = usePeerContext();
   const { datachannels } = useDataChannelContext();
   const { roomID } = useClientContext();
-  const { speakers, host } = useMetadataContext();
+  const { speakers, moderatorIDs, isModerator } = useMetadataContext();
 
-  const isHost = host.clientIDs.includes(stream.clientId);
+  const isHost = moderatorIDs.includes(stream.clientId);
 
   useEffect(() => {
     const videoEl = videoRef.current;

--- a/app/_features/room/components/conference-speaker-layout.tsx
+++ b/app/_features/room/components/conference-speaker-layout.tsx
@@ -5,34 +5,31 @@ import '../styles/conference-speaker.css';
 import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 
 export default function ConferenceSpeakerLayout({
-  isModerator,
   streams,
 }: {
-  isModerator: boolean;
   streams: ParticipantStream[];
 }) {
-  const { host, speakers: speakerClientIDs } = useMetadataContext();
+  const { moderatorIDs, speakers: speakerClientIDs } = useMetadataContext();
 
   const speakers = useMemo(() => {
     return streams.filter((stream) => {
       return (
-        (host.clientIDs.includes(stream.clientId) &&
-          stream.source === 'media') ||
+        (moderatorIDs.includes(stream.clientId) && stream.source === 'media') ||
         (speakerClientIDs.includes(stream.clientId) &&
           stream.source === 'media')
       );
     });
-  }, [streams, host, speakerClientIDs]);
+  }, [streams, moderatorIDs, speakerClientIDs]);
 
   const participants = useMemo(() => {
     return streams.filter((stream) => {
       return (
-        !host.clientIDs.includes(stream.clientId) &&
+        !moderatorIDs.includes(stream.clientId) &&
         !speakerClientIDs.includes(stream.clientId) &&
         stream.source === 'media'
       );
     });
-  }, [streams, host, speakerClientIDs]);
+  }, [streams, moderatorIDs, speakerClientIDs]);
 
   const MAX_VISIBLE_PARTICIPANTS = 20;
   const slicedParticipants = participants.slice(0, MAX_VISIBLE_PARTICIPANTS);
@@ -43,7 +40,7 @@ export default function ConferenceSpeakerLayout({
         {speakers.map((speaker, index) => {
           return (
             <div key={`speaker${index}`} className="relative">
-              <ConferenceScreen stream={speaker} isModerator={isModerator} />
+              <ConferenceScreen stream={speaker} />
             </div>
           );
         })}
@@ -56,10 +53,7 @@ export default function ConferenceSpeakerLayout({
                 key={`participant${index}`}
                 className="participant-item relative"
               >
-                <ConferenceScreen
-                  stream={participant}
-                  isModerator={isModerator}
-                />
+                <ConferenceScreen stream={participant} />
               </div>
             );
           })}

--- a/app/_features/room/components/conference-speaker-layout.tsx
+++ b/app/_features/room/components/conference-speaker-layout.tsx
@@ -37,9 +37,9 @@ export default function ConferenceSpeakerLayout({
   return (
     <div className="conference-layout speaker">
       <div className="speaker-container">
-        {speakers.map((speaker, index) => {
+        {speakers.map((speaker) => {
           return (
-            <div key={`speaker${index}`} className="relative">
+            <div key={`speaker-${speaker.id}`} className="relative">
               <ConferenceScreen stream={speaker} />
             </div>
           );
@@ -47,10 +47,10 @@ export default function ConferenceSpeakerLayout({
       </div>
       <div className="participant-container">
         <div className="participant-grid">
-          {slicedParticipants.map((participant, index) => {
+          {slicedParticipants.map((participant) => {
             return (
               <div
-                key={`participant${index}`}
+                key={`participant-${participant.id}`}
                 className="participant-item relative"
               >
                 <ConferenceScreen stream={participant} />

--- a/app/_features/room/components/conference-speaker-layout.tsx
+++ b/app/_features/room/components/conference-speaker-layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 import ConferenceScreen from '@/_features/room/components/conference-screen';
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { Button, CircularProgress } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -28,7 +28,7 @@ const MeetingRoomLayout = () => {
   const { layout } = useMetadataContext();
 
   if (layout.current === 'presentation') {
-    return <MeetingPresentationLayout />;
+    return <MeetingPresentationLayout streams={streams} />;
   }
 
   if (streams.length === 2 && layout.current === 'gallery') {

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -2,36 +2,52 @@ import { Button, CircularProgress } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
-import { usePeerContext } from '../contexts/peer-context';
-import ConferenceSpeakerLayout from './conference-speaker-layout';
-import ConferencePresentationLayout from './conference-presentation-layout';
 import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
+import { usePeerContext } from '@/_features/room/contexts/peer-context';
+import MeetingOneOnOneLayout from './meeting-one-on-one-layout';
+import MeetingGalleryLayout from './meeting-gallery-layout';
+import MeetingPresentationLayout from './meeting-presentation-layout';
+import WebinarSpeakerLayout from './conference-speaker-layout';
+import WebinarPresentationLayout from './conference-presentation-layout';
 import PlugConnectedFillIcon from '@/_shared/components/icons/plug-connected-fill-icon';
 import PlugDisconnectedFillIcon from '@/_shared/components/icons/plug-disconnected-fill-icon';
 
-export default function Conference({ isModerator }: { isModerator: boolean }) {
+const WebinarRoomLayout = () => {
   const { streams } = useParticipantContext();
   const { layout } = useMetadataContext();
 
+  if (layout.current === 'presentation') {
+    return <WebinarPresentationLayout streams={streams} />;
+  }
+
+  return <WebinarSpeakerLayout streams={streams} />;
+};
+
+const MeetingRoomLayout = () => {
+  const { streams } = useParticipantContext();
+  const { layout } = useMetadataContext();
+
+  if (layout.current === 'presentation') {
+    return <MeetingPresentationLayout />;
+  }
+
+  if (streams.length === 2 && layout.current === 'gallery') {
+    return <MeetingOneOnOneLayout streams={streams} />;
+  }
+
+  return <MeetingGalleryLayout streams={streams} />;
+};
+
+export default function Conference({ roomType }: { roomType: string }) {
   return (
     <>
       <ConnectionStatusOverlay></ConnectionStatusOverlay>
       <div className="viewport-height grid grid-rows-[1fr,80px] overflow-y-hidden">
         <div>
-          {layout === 'speaker' ? (
-            <ConferenceSpeakerLayout
-              isModerator={isModerator}
-              streams={streams}
-            />
-          ) : layout === 'presentation' ? (
-            <ConferencePresentationLayout
-              isModerator={isModerator}
-              streams={streams}
-            />
-          ) : null}
+          {roomType === 'event' ? <WebinarRoomLayout /> : <MeetingRoomLayout />}
         </div>
         <div>
-          <ConferenceActionsBar isModerator={isModerator} />
+          <ConferenceActionsBar />
         </div>
       </div>
     </>

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -16,9 +16,9 @@ import PlugDisconnectedFillIcon from '@/_shared/components/icons/plug-disconnect
 
 const WebinarRoomLayout = () => {
   const { streams } = useParticipantContext();
-  const { layout } = useMetadataContext();
+  const { currentLayout } = useMetadataContext();
 
-  if (layout.current === 'presentation') {
+  if (currentLayout === 'presentation') {
     return <WebinarPresentationLayout streams={streams} />;
   }
 
@@ -27,13 +27,13 @@ const WebinarRoomLayout = () => {
 
 const MeetingRoomLayout = () => {
   const { streams } = useParticipantContext();
-  const { layout } = useMetadataContext();
+  const { currentLayout } = useMetadataContext();
 
-  if (layout.current === 'presentation') {
+  if (currentLayout === 'presentation') {
     return <MeetingPresentationLayout streams={streams} />;
   }
 
-  if (streams.length === 2 && layout.current === 'gallery') {
+  if (streams.length === 2 && currentLayout === 'gallery') {
     return <MeetingOneOnOneLayout streams={streams} />;
   }
 

--- a/app/_features/room/components/meeting-gallery-layout.tsx
+++ b/app/_features/room/components/meeting-gallery-layout.tsx
@@ -21,7 +21,7 @@ export default function MeetingGalleryLayout({
   const maxColumns = Math.ceil(Math.sqrt(visibleParticipants.length));
 
   return (
-    <div className="flex h-full w-full flex-col justify-center p-4">
+    <div className="meeting-gallery-layout flex h-full w-full flex-col justify-center p-4">
       <div className="participant-container">
         <div
           className={`participant-grid grid gap-2 sm:gap-3`}

--- a/app/_features/room/components/meeting-gallery-layout.tsx
+++ b/app/_features/room/components/meeting-gallery-layout.tsx
@@ -1,0 +1,58 @@
+import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
+import '../styles/meeting-gallery-layout.css';
+import ConferenceScreen from './conference-screen';
+import ConferenceScreenHidden from './conference-screen-hidden';
+
+export default function MeetingGalleryLayout({
+  streams,
+}: {
+  streams: ParticipantStream[];
+}) {
+  const MAX_VISIBLE_PARTICIPANTS = 49;
+  const moreThanMax = streams.length > MAX_VISIBLE_PARTICIPANTS;
+  const visibleParticipants = streams.slice(
+    0,
+    moreThanMax ? MAX_VISIBLE_PARTICIPANTS - 1 : MAX_VISIBLE_PARTICIPANTS
+  );
+  const hiddenParticipants = streams.slice(
+    moreThanMax ? MAX_VISIBLE_PARTICIPANTS - 1 : MAX_VISIBLE_PARTICIPANTS
+  );
+
+  const maxColumns = Math.ceil(Math.sqrt(visibleParticipants.length));
+
+  return (
+    <div className="flex h-full w-full flex-col justify-center p-4">
+      <div className="participant-container">
+        <div
+          className={`participant-grid grid gap-2 sm:gap-3`}
+          style={{
+            gridTemplateColumns: `repeat(${maxColumns}, minmax(0, 1fr))`,
+          }}
+        >
+          {visibleParticipants.map((stream, index) => {
+            return (
+              <div className="participant-item" key={`stream${index}`}>
+                <ConferenceScreen stream={stream} />
+              </div>
+            );
+          })}
+          {moreThanMax && (
+            <div className="participant-item">
+              <div className="absolute flex h-full w-full items-center justify-center rounded-lg bg-zinc-800 p-2 text-xs font-medium shadow-lg sm:text-sm">
+                More <span className="hidden sm:inline">+</span>
+              </div>
+              {hiddenParticipants.map((stream, index) => {
+                return (
+                  <ConferenceScreenHidden
+                    key={`hidden-screen-${index}`}
+                    stream={stream}
+                  />
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_features/room/components/meeting-gallery-layout.tsx
+++ b/app/_features/room/components/meeting-gallery-layout.tsx
@@ -21,7 +21,7 @@ export default function MeetingGalleryLayout({
   const maxColumns = Math.ceil(Math.sqrt(visibleParticipants.length));
 
   return (
-    <div className="meeting-gallery-layout flex h-full w-full flex-col justify-center p-4">
+    <div className="meeting-gallery-layout">
       <div className="participant-container">
         <div
           className={`participant-grid grid gap-2 sm:gap-3`}

--- a/app/_features/room/components/meeting-gallery-layout.tsx
+++ b/app/_features/room/components/meeting-gallery-layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
 import '../styles/meeting-gallery-layout.css';
 import ConferenceScreen from './conference-screen';

--- a/app/_features/room/components/meeting-gallery-layout.tsx
+++ b/app/_features/room/components/meeting-gallery-layout.tsx
@@ -29,9 +29,12 @@ export default function MeetingGalleryLayout({
             gridTemplateColumns: `repeat(${maxColumns}, minmax(0, 1fr))`,
           }}
         >
-          {visibleParticipants.map((stream, index) => {
+          {visibleParticipants.map((stream) => {
             return (
-              <div className="participant-item" key={`stream${index}`}>
+              <div
+                className="participant-item"
+                key={`visible-stream-${stream.id}`}
+              >
                 <ConferenceScreen stream={stream} />
               </div>
             );
@@ -41,10 +44,10 @@ export default function MeetingGalleryLayout({
               <div className="absolute flex h-full w-full items-center justify-center rounded-lg bg-zinc-800 p-2 text-xs font-medium shadow-lg sm:text-sm">
                 More <span className="hidden sm:inline">+</span>
               </div>
-              {hiddenParticipants.map((stream, index) => {
+              {hiddenParticipants.map((stream) => {
                 return (
                   <ConferenceScreenHidden
-                    key={`hidden-screen-${index}`}
+                    key={`hidden-screen-${stream.id}`}
                     stream={stream}
                   />
                 );

--- a/app/_features/room/components/meeting-one-on-one-layout.tsx
+++ b/app/_features/room/components/meeting-one-on-one-layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
 import ConferenceScreen from '@/_features/room/components/conference-screen';
 

--- a/app/_features/room/components/meeting-one-on-one-layout.tsx
+++ b/app/_features/room/components/meeting-one-on-one-layout.tsx
@@ -1,0 +1,26 @@
+import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
+import ConferenceScreen from '@/_features/room/components/conference-screen';
+
+export default function MeetingOneOnOneLayout({
+  streams,
+}: {
+  streams: ParticipantStream[];
+}) {
+  const localStream = streams.find((stream) => stream.origin === 'local');
+  const remoteStream = streams.find((stream) => stream.origin === 'remote');
+
+  return (
+    <div className="flex h-full w-full flex-col justify-center p-4">
+      <div className="relative flex h-full w-full flex-col justify-center">
+        <div className="relative aspect-square sm:aspect-auto sm:h-full">
+          {remoteStream && <ConferenceScreen stream={remoteStream} />}
+        </div>
+        <div className="absolute bottom-4 right-4 z-20">
+          <div className="relative aspect-square w-32 sm:aspect-video sm:w-52">
+            {localStream && <ConferenceScreen stream={localStream} />}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_features/room/components/meeting-presentation-layout.tsx
+++ b/app/_features/room/components/meeting-presentation-layout.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useMemo } from 'react';
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
 import '../styles/meeting-presentation-layout.css';

--- a/app/_features/room/components/meeting-presentation-layout.tsx
+++ b/app/_features/room/components/meeting-presentation-layout.tsx
@@ -59,17 +59,20 @@ export default function MeetingPresentationLayout({
             gridTemplateColumns: `repeat(${maxColumns}, minmax(auto, 180px))`,
           }}
         >
-          {visibleStreams.map((stream, index) => {
+          {visibleStreams.map((stream) => {
             return (
-              <div className="participant-item" key={`visible-stream-${index}`}>
+              <div
+                className="participant-item"
+                key={`visible-stream-${stream.id}`}
+              >
                 <ConferenceScreen stream={stream} />
               </div>
             );
           })}
-          {hiddenStreams.map((stream, index) => {
+          {hiddenStreams.map((stream) => {
             return (
               <ConferenceScreenHidden
-                key={`hidden-screen-${index}`}
+                key={`hidden-screen-${stream.id}`}
                 stream={stream}
               />
             );

--- a/app/_features/room/components/meeting-presentation-layout.tsx
+++ b/app/_features/room/components/meeting-presentation-layout.tsx
@@ -1,0 +1,81 @@
+import { useMemo } from 'react';
+import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
+import '../styles/meeting-presentation-layout.css';
+import ConferenceScreen from '@/_features/room/components/conference-screen';
+import ConferenceScreenHidden from './conference-screen-hidden';
+
+export default function MeetingPresentationLayout({
+  streams,
+}: {
+  streams: ParticipantStream[];
+}) {
+  const MAX_VISIBLE_PARTICIPANTS = 6;
+
+  const { screens, medias } = useMemo(() => {
+    return streams.reduce(
+      (accumulator, currentValue) => {
+        if (currentValue.source === 'screen') {
+          return {
+            ...accumulator,
+            screens: [...accumulator.screens, currentValue],
+          };
+        } else {
+          return {
+            ...accumulator,
+            medias: [...accumulator.medias, currentValue],
+          };
+        }
+      },
+      { screens: [] as ParticipantStream[], medias: [] as ParticipantStream[] }
+    );
+  }, [streams]);
+
+  const spotlightScreen = screens.pop();
+  const visibleScreens = screens.slice(0, MAX_VISIBLE_PARTICIPANTS);
+  const inVisibleScreens = screens.slice(MAX_VISIBLE_PARTICIPANTS);
+
+  const visibleParticipants =
+    visibleScreens.length < MAX_VISIBLE_PARTICIPANTS
+      ? medias.slice(0, MAX_VISIBLE_PARTICIPANTS - visibleScreens.length)
+      : [];
+  const invisibleParticipants = medias.slice(visibleParticipants.length);
+
+  const visibleStreams = [...visibleScreens, ...visibleParticipants];
+  const hiddenStreams = [...inVisibleScreens, ...invisibleParticipants];
+
+  const maxColumns = Math.ceil(Math.sqrt(visibleStreams.length));
+
+  return (
+    <div className="meeting-presentation-layout">
+      <div className="presentation-container">
+        <div className="relative h-full w-full">
+          {spotlightScreen && <ConferenceScreen stream={spotlightScreen} />}
+        </div>
+      </div>
+      <div className="participant-container">
+        <div
+          className={`participant-grid grid gap-3`}
+          style={{
+            gridTemplateColumns: `repeat(${maxColumns}, minmax(auto, 180px))`,
+          }}
+        >
+          {visibleStreams.map((stream, index) => {
+            return (
+              <div className="participant-item" key={`visible-stream-${index}`}>
+                <ConferenceScreen stream={stream} />
+              </div>
+            );
+          })}
+          {hiddenStreams.map((stream, index) => {
+            return (
+              <ConferenceScreenHidden
+                key={`hidden-screen-${index}`}
+                stream={stream}
+              />
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_features/room/components/view.tsx
+++ b/app/_features/room/components/view.tsx
@@ -18,10 +18,10 @@ import type { ClientType } from '@/_shared/types/client';
 type ViewProps = {
   roomID: string;
   client: ClientType.ClientData;
-  isModerator: boolean;
+  roomType: string;
 };
 
-export default function View({ roomID, client, isModerator }: ViewProps) {
+export default function View({ roomID, client, roomType }: ViewProps) {
   const { active: isConferenceActive, setActive: setActiveConference } =
     useToggle(false);
 
@@ -46,9 +46,9 @@ export default function View({ roomID, client, isModerator }: ViewProps) {
                 <ChatProvider>
                   <EventContainer>
                     <ChatDrawerMenu />
-                    <MetadataProvider roomID={roomID}>
+                    <MetadataProvider roomID={roomID} roomType={roomType}>
                       {isConferenceActive ? (
-                        <Conference isModerator={isModerator} />
+                        <Conference roomType={roomType} />
                       ) : (
                         <Lobby roomID={roomID} />
                       )}

--- a/app/_features/room/contexts/metadata-context.tsx
+++ b/app/_features/room/contexts/metadata-context.tsx
@@ -71,10 +71,16 @@ export function MetadataProvider({
         }
 
         if (availableStream.source === 'screen') {
-          setMetadataState((prevData) => ({
-            ...prevData,
-            currentLayout: 'presentation',
-          }));
+          setMetadataState((prevData) => {
+            if (prevData.currentLayout === 'presentation') {
+              return prevData;
+            }
+
+            return {
+              ...prevData,
+              currentLayout: 'presentation',
+            };
+          });
         }
       }
     );
@@ -82,17 +88,25 @@ export function MetadataProvider({
     clientSDK.on(
       RoomEvent.STREAM_REMOVED,
       async ({ stream: removedStream }: { stream: ParticipantStream }) => {
-        const streams = peer.getAllStreams();
+        if (removedStream.source === 'screen') {
+          const streams = peer.getAllStreams();
 
-        const screen = streams.find((stream) => {
-          return stream.source === 'screen';
-        });
+          const screen = streams.find((stream) => {
+            return stream.source === 'screen';
+          });
 
-        if (removedStream.source === 'screen' && !screen) {
-          setMetadataState((prevData) => ({
-            ...prevData,
-            currentLayout: prevData.previousLayout,
-          }));
+          if (!screen) {
+            setMetadataState((prevData) => {
+              if (prevData.currentLayout === prevData.previousLayout) {
+                return prevData;
+              }
+
+              return {
+                ...prevData,
+                currentLayout: prevData.previousLayout,
+              };
+            });
+          }
         }
       }
     );

--- a/app/_features/room/contexts/metadata-context.tsx
+++ b/app/_features/room/contexts/metadata-context.tsx
@@ -63,7 +63,10 @@ export function MetadataProvider({
           availableStream.source === 'screen' &&
           availableStream.origin === 'local'
         ) {
-          if (metadataState.previousLayout !== metadataState.currentLayout) {
+          if (
+            metadataState.previousLayout !== metadataState.currentLayout &&
+            metadataState.currentLayout !== 'presentation'
+          ) {
             await clientSDK.setMetadata(roomID, {
               previousLayout: metadataState.currentLayout,
             });

--- a/app/_features/room/styles/meeting-gallery-layout.css
+++ b/app/_features/room/styles/meeting-gallery-layout.css
@@ -1,19 +1,19 @@
-.participant-container {
+.meeting-gallery-layout .participant-container {
   aspect-ratio: 1/1;
 }
 
 @media (min-width: 576px) {
-  .participant-container {
+  .meeting-gallery-layout .participant-container {
     aspect-ratio: auto;
     height: 100%;
   }
 }
 
-.participant-grid {
+.meeting-gallery-layout .participant-grid {
   height: 100%;
 }
 
-.participant-item {
+.meeting-gallery-layout .participant-item {
   position: relative;
   width: 100%;
   aspect-ratio: 1/1;
@@ -23,7 +23,7 @@
 }
 
 @media (min-width: 576px) {
-  .participant-item {
+  .meeting-gallery-layout .participant-item {
     aspect-ratio: auto;
     height: 100%;
   }

--- a/app/_features/room/styles/meeting-gallery-layout.css
+++ b/app/_features/room/styles/meeting-gallery-layout.css
@@ -1,0 +1,30 @@
+.participant-container {
+  aspect-ratio: 1/1;
+}
+
+@media (min-width: 576px) {
+  .participant-container {
+    aspect-ratio: auto;
+    height: 100%;
+  }
+}
+
+.participant-grid {
+  height: 100%;
+}
+
+.participant-item {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1/1;
+  vertical-align: middle;
+  align-self: center;
+  border-radius: 10px;
+}
+
+@media (min-width: 576px) {
+  .participant-item {
+    aspect-ratio: auto;
+    height: 100%;
+  }
+}

--- a/app/_features/room/styles/meeting-gallery-layout.css
+++ b/app/_features/room/styles/meeting-gallery-layout.css
@@ -1,3 +1,13 @@
+.meeting-gallery-layout {
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 1rem;
+}
+
 .meeting-gallery-layout .participant-container {
   aspect-ratio: 1/1;
 }

--- a/app/_features/room/styles/meeting-presentation-layout.css
+++ b/app/_features/room/styles/meeting-presentation-layout.css
@@ -81,6 +81,5 @@
 @media only screen and (min-width: 1024px) {
   .meeting-presentation-layout .participant-grid {
     grid-template-columns: minmax(0, 200px) !important;
-    /* grid-template-rows: repeat(auto-fit, minmax(auto, 200px)); */
   }
 }

--- a/app/_features/room/styles/meeting-presentation-layout.css
+++ b/app/_features/room/styles/meeting-presentation-layout.css
@@ -1,0 +1,86 @@
+.meeting-presentation-layout {
+  width: 100%;
+  height: 100%;
+  padding: 1rem;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  gap: 1rem;
+}
+
+@media only screen and (orientation: portrait) and (max-width: 1023px) {
+  .meeting-presentation-layout .presentation-container {
+    aspect-ratio: 16/9;
+  }
+}
+
+@media only screen and (orientation: landscape) {
+  .meeting-presentation-layout {
+    display: grid;
+    grid-template-rows: 2fr 1fr;
+  }
+
+  .meeting-presentation-layout .presentation-container {
+    aspect-ratio: auto;
+  }
+}
+
+@media only screen and (orientation: landscape) and (hover: none) and (pointer: coarse) and (max-width: 1023px) {
+  .meeting-presentation-layout {
+    grid-template-rows: 100% auto;
+  }
+
+  .meeting-presentation-layout .participant-container {
+    display: none;
+  }
+}
+
+@media (min-width: 1024px) {
+  .meeting-presentation-layout {
+    display: grid;
+    grid-template-columns: 4fr 1fr;
+    grid-template-rows: auto;
+    gap: 2rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .meeting-presentation-layout {
+    display: grid;
+    rid-template-columns: 4fr 1fr;
+    grid-template-rows: auto;
+  }
+}
+
+.meeting-presentation-layout .participant-grid {
+  height: 100%;
+  align-content: flex-start;
+  justify-content: center;
+}
+
+.meeting-presentation-layout .participant-item {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4/3;
+  vertical-align: middle;
+  align-self: center;
+  border-radius: 10px;
+}
+
+@media (min-width: 576px) {
+  .meeting-presentation-layout .participant-grid {
+    align-content: normal;
+  }
+
+  .meeting-presentation-layout .participant-item {
+    aspect-ratio: auto;
+    height: 100%;
+    max-height: 200px;
+  }
+}
+
+@media only screen and (min-width: 1024px) {
+  .meeting-presentation-layout .participant-grid {
+    grid-template-columns: minmax(0, 200px) !important;
+    /* grid-template-rows: repeat(auto-fit, minmax(auto, 200px)); */
+  }
+}


### PR DESCRIPTION
## Description
In this PR, we put back the meeting room layout again. However, in the future when creating a room, there will be an option to create a room for meeting or create a room for webinar event. The current implementation will use meeting room layout as default layout. The meeting room preset is back that consists of gallery, one on one, and presentation layouts.

All participants are able to mute and unmute again. However, the first time user joins, they will be automatically muted. All participants are also rendered, even when they are not currently displayed on the screen. So, everyone is able to hear anyone voice when they unmute the mic.