### PR TITLE
feat: add top bar and gallery layout options to the webinar room

### DIFF
--- a/app/_features/room/components/conference-actions-bar.tsx
+++ b/app/_features/room/components/conference-actions-bar.tsx
@@ -16,8 +16,8 @@ export default function ConferenceActionsBar() {
   }, []);
 
   return (
-    <div className="fixed bottom-0 left-0 z-20 h-20 w-full bg-zinc-900">
-      <div className="flex h-full w-full items-center justify-center gap-4 border-t border-neutral-700 px-4 py-1.5 md:py-2.5 lg:gap-6">
+    <div className="fixed bottom-0 left-0 z-20 h-[72px] w-full bg-zinc-900">
+      <div className="flex h-full w-full items-center justify-center gap-4 px-4 py-1.5 md:py-3 lg:gap-6">
         <div className="flex h-full flex-col justify-center">
           <ButtonMicrophone />
         </div>

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -183,48 +183,36 @@ export default function ConferenceScreen({
       if (key === 'set-speaker') {
         if (!isModerator) return;
 
-        const confirmed = confirm(
-          'Are you sure you want to set this participant as a speaker?'
-        );
-
-        if (confirmed) {
-          try {
-            await clientSDK.setMetadata(roomID, {
-              speakerClientIDs: [...speakerClientIDs, stream.clientId],
-            });
-          } catch (error) {
-            Sentry.captureException(error, {
-              extra: {
-                message: `API call error when trying to set metadata speakerClientIDs`,
-              },
-            });
-            console.error(error);
-          }
+        try {
+          await clientSDK.setMetadata(roomID, {
+            speakerClientIDs: [...speakerClientIDs, stream.clientId],
+          });
+        } catch (error) {
+          Sentry.captureException(error, {
+            extra: {
+              message: `API call error when trying to set metadata speakerClientIDs`,
+            },
+          });
+          console.error(error);
         }
       } else if (key === 'set-regular-participant') {
         if (!isModerator) return;
 
-        const confirmed = confirm(
-          'Are you sure you want to set this speaker as a regular participant?'
-        );
+        try {
+          const newSpeakerClientIDs = speakerClientIDs.filter((speaker) => {
+            return speaker !== stream.clientId;
+          });
 
-        if (confirmed) {
-          try {
-            const newSpeakerClientIDs = speakerClientIDs.filter((speaker) => {
-              return speaker !== stream.clientId;
-            });
-
-            await clientSDK.setMetadata(roomID, {
-              speakerClientIDs: newSpeakerClientIDs,
-            });
-          } catch (error) {
-            Sentry.captureException(error, {
-              extra: {
-                message: `API call error when trying to set metadata speakerClientIDs`,
-              },
-            });
-            console.error(error);
-          }
+          await clientSDK.setMetadata(roomID, {
+            speakerClientIDs: newSpeakerClientIDs,
+          });
+        } catch (error) {
+          Sentry.captureException(error, {
+            extra: {
+              message: `API call error when trying to set metadata speakerClientIDs`,
+            },
+          });
+          console.error(error);
         }
       }
     },

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -65,7 +65,7 @@ export default function ConferenceScreen({
 
   const { peer } = usePeerContext();
   const { datachannels } = useDataChannelContext();
-  const { roomID } = useClientContext();
+  const { roomID, clientID } = useClientContext();
   const {
     speakerClientIDs,
     moderatorClientIDs,
@@ -437,6 +437,7 @@ export default function ConferenceScreen({
             </Button>
           )}
         {isModerator &&
+          clientID !== stream.clientId &&
           stream.source === 'media' &&
           roomType === 'event' &&
           currentLayout === 'speaker' && (

--- a/app/_features/room/components/conference-screen.tsx
+++ b/app/_features/room/components/conference-screen.tsx
@@ -66,8 +66,13 @@ export default function ConferenceScreen({
   const { peer } = usePeerContext();
   const { datachannels } = useDataChannelContext();
   const { roomID } = useClientContext();
-  const { speakerClientIDs, moderatorClientIDs, isModerator, roomType } =
-    useMetadataContext();
+  const {
+    speakerClientIDs,
+    moderatorClientIDs,
+    isModerator,
+    roomType,
+    currentLayout,
+  } = useMetadataContext();
 
   const isHost = moderatorClientIDs.includes(stream.clientId);
   const [rtcLocalStats, setRtcLocalStats] = useState({
@@ -431,29 +436,37 @@ export default function ConferenceScreen({
               <XFillIcon className="h-4 w-4" />
             </Button>
           )}
-        {isModerator && stream.source === 'media' && roomType === 'event' && (
-          <Dropdown placement="bottom" className="ring-1 ring-zinc-800/70">
-            <DropdownTrigger>
-              <Button
-                isIconOnly
-                size="sm"
-                variant="light"
-                className="absolute right-1 top-1 h-7 w-7 min-w-0 rounded-full bg-zinc-700/70 text-zinc-100 opacity-0 hover:!bg-zinc-700 active:bg-zinc-600 group-hover:opacity-100 group-active:opacity-100"
+        {isModerator &&
+          stream.source === 'media' &&
+          roomType === 'event' &&
+          currentLayout === 'speaker' && (
+            <Dropdown placement="bottom" className="ring-1 ring-zinc-800/70">
+              <DropdownTrigger>
+                <Button
+                  isIconOnly
+                  size="sm"
+                  variant="light"
+                  className="absolute right-1 top-1 h-7 w-7 min-w-0 rounded-full bg-zinc-700/70 text-zinc-100 opacity-0 hover:!bg-zinc-700 active:bg-zinc-600 group-hover:opacity-100 group-active:opacity-100"
+                >
+                  <MoreIcon className="h-4 w-4" />
+                </Button>
+              </DropdownTrigger>
+              <DropdownMenu
+                aria-label="More options"
+                onAction={onMoreSelection}
               >
-                <MoreIcon className="h-4 w-4" />
-              </Button>
-            </DropdownTrigger>
-            <DropdownMenu aria-label="More options" onAction={onMoreSelection}>
-              {speakerClientIDs.includes(stream.clientId) ? (
-                <DropdownItem key="set-regular-participant">
-                  Set as a regular participant
-                </DropdownItem>
-              ) : (
-                <DropdownItem key="set-speaker">Set as a speaker</DropdownItem>
-              )}
-            </DropdownMenu>
-          </Dropdown>
-        )}
+                {speakerClientIDs.includes(stream.clientId) ? (
+                  <DropdownItem key="set-regular-participant">
+                    Set as a regular participant
+                  </DropdownItem>
+                ) : (
+                  <DropdownItem key="set-speaker">
+                    Set as a speaker
+                  </DropdownItem>
+                )}
+              </DropdownMenu>
+            </Dropdown>
+          )}
 
         <div className="flex">
           <div

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import {
+  Button,
+  CircularProgress,
+  Dropdown,
+  DropdownTrigger,
+  DropdownMenu,
+  DropdownItem,
+  type Selection,
+} from '@nextui-org/react';
+import { useCallback, useEffect, useState } from 'react';
+import { usePeerContext } from '@/_features/room/contexts/peer-context';
+import { useClientContext } from '@/_features/room/contexts/client-context';
+import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
+import PlugConnectedFillIcon from '@/_shared/components/icons/plug-connected-fill-icon';
+import PlugDisconnectedFillIcon from '@/_shared/components/icons/plug-disconnected-fill-icon';
+import { clientSDK } from '@/_shared/utils/sdk';
+import type { SVGElementPropsType } from '@/_shared/types/types';
+
+export default function ConferenceTopBar() {
+  const { roomType } = useMetadataContext();
+
+  return (
+    <div className="flex items-center justify-between px-4">
+      <div className="flex items-center">
+        <ConnectionStatusOverlay></ConnectionStatusOverlay>
+      </div>
+      <div className="flex items-center">
+        {roomType === 'event' && <DropdownViewSelection />}
+      </div>
+    </div>
+  );
+}
+
+function DropdownViewSelection() {
+  const { previousLayout, currentLayout } = useMetadataContext();
+  const { roomID } = useClientContext();
+
+  const [selectedKeys, setSelectedKeys] = useState(
+    currentLayout !== 'presentation'
+      ? new Set([currentLayout])
+      : new Set([previousLayout])
+  );
+
+  const onViewSelectionChange = useCallback(
+    async (selectedKey: Selection) => {
+      if (!(selectedKey instanceof Set) || selectedKey.size === 0) return;
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      const currentKey: 'gallery' | 'speaker' = selectedKey.currentKey;
+
+      await clientSDK.setMetadata(roomID, {
+        currentLayout: currentKey,
+        previousLayout: currentLayout,
+      });
+
+      setSelectedKeys(new Set([currentKey]));
+    },
+    [roomID, currentLayout]
+  );
+
+  return (
+    <Dropdown className="min-w-40 ring-1 ring-zinc-800/70">
+      <DropdownTrigger>
+        <Button className="h-7 min-w-0 gap-0 rounded bg-transparent px-2 text-xs font-medium text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 active:bg-zinc-700">
+          <span>
+            <GridViewIcon className="h-5 w-5" />
+          </span>
+          <span className="ml-1.5">View</span>
+          <span className="ml-1">
+            <ChevronDownIcon className="h-3 w-3" />
+          </span>
+        </Button>
+      </DropdownTrigger>
+      <DropdownMenu
+        disallowEmptySelection
+        aria-label="Choose a view"
+        selectionMode="single"
+        selectedKeys={selectedKeys}
+        onSelectionChange={onViewSelectionChange}
+      >
+        <DropdownItem
+          key="speaker"
+          className="py-1 text-zinc-400 hover:text-zinc-200"
+          textValue="Speaker View"
+        >
+          <div className="flex items-center gap-1.5 text-xs font-medium">
+            <span>
+              <ThreeGridIcon className="h-6 w-6" />
+            </span>
+            <span>Speaker View</span>
+          </div>
+        </DropdownItem>
+        <DropdownItem
+          key="gallery"
+          className="py-1 text-zinc-400 hover:text-zinc-200"
+          textValue="Gallery View"
+        >
+          <div className="flex items-center gap-1.5 text-xs font-medium">
+            <span>
+              <FourGridIcon className="h-6 w-6" />
+            </span>
+            <span>Gallery View</span>
+          </div>
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  );
+}
+
+function GridViewIcon(props: SVGElementPropsType) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M6.25 12.5c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4Zm7.5 0c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4ZM6.25 7C5.56 7 5 7.56 5 8.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4Zm7.5 0c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2C19 7.56 18.44 7 17.75 7h-4ZM2 6.75A2.75 2.75 0 0 1 4.75 4h14.5A2.75 2.75 0 0 1 22 6.75v10.5A2.75 2.75 0 0 1 19.25 20H4.75A2.75 2.75 0 0 1 2 17.25V6.75ZM4.75 5.5c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V6.75c0-.69-.56-1.25-1.25-1.25H4.75Z"
+      />
+    </svg>
+  );
+}
+
+function ChevronDownIcon(props: SVGElementPropsType) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" {...props}>
+      <path
+        fill="currentColor"
+        d="M2.22 4.47a.75.75 0 0 1 1.06 0L6 7.19l2.72-2.72a.75.75 0 0 1 1.06 1.06L6.53 8.78a.75.75 0 0 1-1.06 0L2.22 5.53a.75.75 0 0 1 0-1.06Z"
+      />
+    </svg>
+  );
+}
+
+function ThreeGridIcon(props: SVGElementPropsType) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" {...props}>
+      <path
+        fill="currentColor"
+        d="M6 3a3 3 0 0 0-3 3v3.5h14V6a3 3 0 0 0-3-3zm11 7.5h-6.5V17H14a3 3 0 0 0 3-3zm-7.5 0H3V14a3 3 0 0 0 3 3h3.5z"
+      />
+    </svg>
+  );
+}
+
+function FourGridIcon(props: SVGElementPropsType) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M17.75 21h-5v-8.25H21v5A3.25 3.25 0 0 1 17.75 21M21 11.25h-8.25V3h5A3.25 3.25 0 0 1 21 6.25zm-9.75 0V3h-5A3.25 3.25 0 0 0 3 6.25v5zM3 12.75v5A3.25 3.25 0 0 0 6.25 21h5v-8.25z"
+      />
+    </svg>
+  );
+}
+
+function ConnectionStatusOverlay() {
+  const { peer } = usePeerContext();
+  const [connectionState, setConnectionState] = useState('connecting');
+
+  useEffect(() => {
+    const peerConnection = peer?.getPeerConnection();
+
+    if (!peerConnection) return;
+
+    peerConnection.addEventListener('iceconnectionstatechange', () => {
+      if (
+        peerConnection.iceConnectionState === 'connected' ||
+        peerConnection.iceConnectionState === 'completed'
+      ) {
+        setConnectionState('connected');
+      } else if (peerConnection.iceConnectionState === 'failed') {
+        setConnectionState('disconnected');
+      } else {
+        setConnectionState('connecting');
+      }
+    });
+  }, [peer]);
+
+  return (
+    <div>
+      {connectionState === 'connecting' && (
+        <div className="flex items-center">
+          <CircularProgress
+            classNames={{ svg: 'h-6 w-6' }}
+            strokeWidth={4}
+            aria-label="Connecting"
+          />
+          <span className="ml-1.5 hidden text-xs font-medium text-zinc-300 sm:inline-block">
+            Connecting
+          </span>
+        </div>
+      )}
+      {connectionState === 'connected' && (
+        <div className="flex items-center">
+          <PlugConnectedFillIcon className="h-6 w-6 text-green-600" />
+          <span className="ml-1.5 hidden text-xs font-medium text-zinc-300 sm:inline-block">
+            Connected
+          </span>
+        </div>
+      )}
+      {connectionState === 'disconnected' && (
+        <div className="flex items-center">
+          <PlugDisconnectedFillIcon className="h-6 w-6 text-red-600" />
+          <span className="ml-1.5 hidden text-xs font-medium text-zinc-300 sm:inline-block">
+            Disconnected
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -12,6 +12,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import { useClientContext } from '@/_features/room/contexts/client-context';
+import { useParticipantContext } from '@/_features/room/contexts/participant-context';
 import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
 import PlugConnectedFillIcon from '@/_shared/components/icons/plug-connected-fill-icon';
 import PlugDisconnectedFillIcon from '@/_shared/components/icons/plug-disconnected-fill-icon';
@@ -20,13 +21,22 @@ import type { SVGElementPropsType } from '@/_shared/types/types';
 
 export default function ConferenceTopBar() {
   const { roomType } = useMetadataContext();
+  const { streams } = useParticipantContext();
+
+  const participants = streams.filter((stream) => stream.source === 'media');
 
   return (
     <div className="flex items-center justify-between px-4">
       <div className="flex items-center">
         <ConnectionStatusOverlay></ConnectionStatusOverlay>
       </div>
-      <div className="flex items-center">
+      <div className="flex items-center gap-2 sm:gap-3">
+        <div className="flex items-center text-xs text-zinc-400">
+          <span>
+            <UserIcon className="h-5 w-5" />
+          </span>
+          <span className="ml-1.5">{participants.length}</span>
+        </div>
         {roomType === 'event' && <DropdownViewSelection />}
       </div>
     </div>
@@ -124,6 +134,17 @@ function ChevronDownIcon(props: SVGElementPropsType) {
       <path
         fill="currentColor"
         d="M2.22 4.47a.75.75 0 0 1 1.06 0L6 7.19l2.72-2.72a.75.75 0 0 1 1.06 1.06L6.53 8.78a.75.75 0 0 1-1.06 0L2.22 5.53a.75.75 0 0 1 0-1.06Z"
+      />
+    </svg>
+  );
+}
+
+function UserIcon(props: SVGElementPropsType) {
+  return (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
+      <path
+        fill="currentColor"
+        d="M17.754 14a2.249 2.249 0 0 1 2.249 2.25v.918a2.75 2.75 0 0 1-.513 1.598c-1.545 2.164-4.07 3.235-7.49 3.235c-3.421 0-5.944-1.072-7.486-3.236a2.75 2.75 0 0 1-.51-1.596v-.92A2.249 2.249 0 0 1 6.251 14h11.502ZM12 2.005a5 5 0 1 1 0 10a5 5 0 0 1 0-10Z"
       />
     </svg>
   );

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -31,7 +31,7 @@ export default function ConferenceTopBar() {
         <ConnectionStatusOverlay></ConnectionStatusOverlay>
       </div>
       <div className="flex items-center gap-2 sm:gap-3">
-        <div className="flex items-center text-xs text-zinc-400">
+        <div className="flex items-center text-xs font-medium tabular-nums text-zinc-400">
           <span>
             <UserIcon className="h-5 w-5" />
           </span>

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -71,7 +71,16 @@ function DropdownViewSelection() {
   return (
     <Dropdown className="min-w-40 ring-1 ring-zinc-800/70">
       <DropdownTrigger>
-        <Button className="h-7 min-w-0 gap-0 rounded bg-transparent px-2 text-xs font-medium text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 active:bg-zinc-700">
+        <Button
+          className={`h-7 min-w-0 gap-0 rounded bg-transparent px-2 text-xs font-medium text-zinc-400 hover:bg-zinc-800 hover:text-zinc-200 active:bg-zinc-700 ${
+            currentLayout === 'presentation'
+              ? 'cursor-not-allowed'
+              : 'cursor-auto'
+          }`}
+          isDisabled={currentLayout === 'presentation'}
+          aria-disabled={currentLayout === 'presentation'}
+          disabled={currentLayout === 'presentation'}
+        >
           <span>
             <GridViewIcon className="h-5 w-5" />
           </span>

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -20,7 +20,7 @@ import { clientSDK } from '@/_shared/utils/sdk';
 import type { SVGElementPropsType } from '@/_shared/types/types';
 
 export default function ConferenceTopBar() {
-  const { roomType } = useMetadataContext();
+  const { roomType, isModerator } = useMetadataContext();
   const { streams } = useParticipantContext();
 
   const participants = streams.filter((stream) => stream.source === 'media');
@@ -37,7 +37,7 @@ export default function ConferenceTopBar() {
           </span>
           <span className="ml-1.5">{participants.length}</span>
         </div>
-        {roomType === 'event' && <DropdownViewSelection />}
+        {roomType === 'event' && isModerator && <DropdownViewSelection />}
       </div>
     </div>
   );

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -37,12 +37,6 @@ function DropdownViewSelection() {
   const { previousLayout, currentLayout } = useMetadataContext();
   const { roomID } = useClientContext();
 
-  const [selectedKeys, setSelectedKeys] = useState(
-    currentLayout !== 'presentation'
-      ? new Set([currentLayout])
-      : new Set([previousLayout])
-  );
-
   const onViewSelectionChange = useCallback(
     async (selectedKey: Selection) => {
       if (!(selectedKey instanceof Set) || selectedKey.size === 0) return;
@@ -55,11 +49,14 @@ function DropdownViewSelection() {
         currentLayout: currentKey,
         previousLayout: currentLayout,
       });
-
-      setSelectedKeys(new Set([currentKey]));
     },
     [roomID, currentLayout]
   );
+
+  const selectedKeys =
+    currentLayout !== 'presentation'
+      ? new Set([currentLayout])
+      : new Set([previousLayout]);
 
   return (
     <Dropdown className="min-w-40 ring-1 ring-zinc-800/70">

--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -75,7 +75,10 @@ function DropdownViewSelection() {
           <span>
             <GridViewIcon className="h-5 w-5" />
           </span>
-          <span className="ml-1.5">View</span>
+          <span className="ml-1.5 capitalize">
+            {currentLayout !== 'presentation' ? currentLayout : previousLayout}{' '}
+            View
+          </span>
           <span className="ml-1">
             <ChevronDownIcon className="h-3 w-3" />
           </span>

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -45,7 +45,7 @@ export default function Conference({ roomType }: { roomType: string }) {
     <>
       <div className="viewport-height grid grid-rows-[40px,1fr,72px] overflow-y-hidden">
         <ConferenceTopBar />
-        <div>
+        <div className="px-4 pb-4">
           {roomType === 'event' ? <WebinarRoomLayout /> : <MeetingRoomLayout />}
         </div>
         <div>

--- a/app/_features/room/components/conference.tsx
+++ b/app/_features/room/components/conference.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import { Button, CircularProgress } from '@nextui-org/react';
-import { useEffect, useState } from 'react';
+import ConferenceTopBar from '@/_features/room/components/conference-top-bar';
 import ConferenceActionsBar from '@/_features/room/components/conference-actions-bar';
 import { useParticipantContext } from '@/_features/room/contexts/participant-context';
 import { useMetadataContext } from '@/_features/room/contexts/metadata-context';
-import { usePeerContext } from '@/_features/room/contexts/peer-context';
 import MeetingOneOnOneLayout from './meeting-one-on-one-layout';
-import MeetingGalleryLayout from './meeting-gallery-layout';
 import MeetingPresentationLayout from './meeting-presentation-layout';
+import GalleryLayout from './gallery-layout';
 import WebinarSpeakerLayout from './webinar-speaker-layout';
 import WebinarPresentationLayout from './webinar-presentation-layout';
-import PlugConnectedFillIcon from '@/_shared/components/icons/plug-connected-fill-icon';
-import PlugDisconnectedFillIcon from '@/_shared/components/icons/plug-disconnected-fill-icon';
 
 const WebinarRoomLayout = () => {
   const { streams } = useParticipantContext();
@@ -22,7 +18,11 @@ const WebinarRoomLayout = () => {
     return <WebinarPresentationLayout streams={streams} />;
   }
 
-  return <WebinarSpeakerLayout streams={streams} />;
+  if (currentLayout === 'speaker') {
+    return <WebinarSpeakerLayout streams={streams} />;
+  }
+
+  return <GalleryLayout streams={streams} />;
 };
 
 const MeetingRoomLayout = () => {
@@ -37,14 +37,14 @@ const MeetingRoomLayout = () => {
     return <MeetingOneOnOneLayout streams={streams} />;
   }
 
-  return <MeetingGalleryLayout streams={streams} />;
+  return <GalleryLayout streams={streams} />;
 };
 
 export default function Conference({ roomType }: { roomType: string }) {
   return (
     <>
-      <ConnectionStatusOverlay></ConnectionStatusOverlay>
-      <div className="viewport-height grid grid-rows-[1fr,80px] overflow-y-hidden">
+      <div className="viewport-height grid grid-rows-[40px,1fr,72px] overflow-y-hidden">
+        <ConferenceTopBar />
         <div>
           {roomType === 'event' ? <WebinarRoomLayout /> : <MeetingRoomLayout />}
         </div>
@@ -53,52 +53,5 @@ export default function Conference({ roomType }: { roomType: string }) {
         </div>
       </div>
     </>
-  );
-}
-
-function ConnectionStatusOverlay() {
-  const { peer } = usePeerContext();
-  const [connectionState, setConnectionState] = useState('connecting');
-
-  useEffect(() => {
-    if (!peer) return;
-
-    const peerConnection = peer.getPeerConnection();
-
-    if (!peerConnection) return;
-
-    peerConnection.addEventListener('iceconnectionstatechange', () => {
-      if (
-        peerConnection.iceConnectionState === 'connected' ||
-        peerConnection.iceConnectionState === 'completed'
-      ) {
-        setConnectionState('connected');
-      } else if (peerConnection.iceConnectionState === 'failed') {
-        setConnectionState('disconnected');
-      } else {
-        setConnectionState('connecting');
-      }
-    });
-  }, [peer]);
-
-  return (
-    <div className="absolute left-4 top-4 z-40 p-2">
-      <Button
-        disabled
-        isIconOnly
-        className="h-8 w-8 min-w-0 rounded-lg p-1 shadow-sm"
-      >
-        {connectionState === 'connecting' && (
-          <CircularProgress className="h-5 w-5 min-w-0" strokeWidth={8} />
-        )}
-
-        {connectionState === 'connected' && (
-          <PlugConnectedFillIcon className="h-5 w-5" fill="#22C55E" />
-        )}
-        {connectionState === 'disconnected' && (
-          <PlugDisconnectedFillIcon className="h-5 w-5" fill="#EF4444" />
-        )}
-      </Button>
-    </div>
   );
 }

--- a/app/_features/room/components/gallery-layout.tsx
+++ b/app/_features/room/components/gallery-layout.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo } from 'react';
 import { type ParticipantStream } from '@/_features/room/contexts/participant-context';
-import '../styles/meeting-gallery-layout.css';
+import '../styles/gallery-layout.css';
 import ConferenceScreen from './conference-screen';
 import ConferenceScreenHidden from './conference-screen-hidden';
 
@@ -29,7 +29,7 @@ export default function MeetingGalleryLayout({
   const maxColumns = Math.ceil(Math.sqrt(visibleParticipants.length));
 
   return (
-    <div className="meeting-gallery-layout">
+    <div className="gallery-layout">
       <div className="participant-container">
         <div
           className={`participant-grid grid gap-2 sm:gap-3`}

--- a/app/_features/room/components/meeting-one-on-one-layout.tsx
+++ b/app/_features/room/components/meeting-one-on-one-layout.tsx
@@ -12,7 +12,7 @@ export default function MeetingOneOnOneLayout({
   const remoteStream = streams.find((stream) => stream.origin === 'remote');
 
   return (
-    <div className="flex h-full w-full flex-col justify-center p-4">
+    <div className="flex h-full w-full flex-col justify-center">
       <div className="relative flex h-full w-full flex-col justify-center">
         <div className="relative aspect-square sm:aspect-auto sm:h-full">
           {remoteStream && <ConferenceScreen stream={remoteStream} />}

--- a/app/_features/room/styles/gallery-layout.css
+++ b/app/_features/room/styles/gallery-layout.css
@@ -1,7 +1,6 @@
 .gallery-layout {
   width: 100%;
   height: 100%;
-  padding: 1rem;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/app/_features/room/styles/gallery-layout.css
+++ b/app/_features/room/styles/gallery-layout.css
@@ -1,4 +1,4 @@
-.meeting-gallery-layout {
+.gallery-layout {
   width: 100%;
   height: 100%;
   padding: 1rem;
@@ -8,22 +8,22 @@
   gap: 1rem;
 }
 
-.meeting-gallery-layout .participant-container {
+.gallery-layout .participant-container {
   aspect-ratio: 1/1;
 }
 
 @media (min-width: 576px) {
-  .meeting-gallery-layout .participant-container {
+  .gallery-layout .participant-container {
     aspect-ratio: auto;
     height: 100%;
   }
 }
 
-.meeting-gallery-layout .participant-grid {
+.gallery-layout .participant-grid {
   height: 100%;
 }
 
-.meeting-gallery-layout .participant-item {
+.gallery-layout .participant-item {
   position: relative;
   width: 100%;
   aspect-ratio: 1/1;
@@ -33,7 +33,7 @@
 }
 
 @media (min-width: 576px) {
-  .meeting-gallery-layout .participant-item {
+  .gallery-layout .participant-item {
     aspect-ratio: auto;
     height: 100%;
   }

--- a/app/_features/room/styles/meeting-presentation-layout.css
+++ b/app/_features/room/styles/meeting-presentation-layout.css
@@ -1,7 +1,6 @@
 .meeting-presentation-layout {
   width: 100%;
   height: 100%;
-  padding: 1rem;
   display: grid;
   grid-template-rows: auto 1fr;
   gap: 1rem;

--- a/app/_features/room/styles/webinar-presentation-layout.css
+++ b/app/_features/room/styles/webinar-presentation-layout.css
@@ -1,7 +1,6 @@
 .webinar-presentation-layout {
   width: 100%;
   height: 100%;
-  padding: 1rem;
   display: grid;
   grid-template-rows: auto 1fr;
   gap: 1rem;

--- a/app/_features/room/styles/webinar-speaker-layout.css
+++ b/app/_features/room/styles/webinar-speaker-layout.css
@@ -1,7 +1,6 @@
 .conference-layout.speaker {
   width: 100%;
   height: 100%;
-  padding: 1rem;
   display: grid;
   grid-template-rows: 1fr;
   gap: 1rem;


### PR DESCRIPTION
## Changelogs
- Add topbar in the room
- Put connection status on the left side of topbar
- Put the mode/view selection on the right side of topbar. View selection can only be viewed by moderator and only available for webinar room. Moderator can select between speaker or gallery views.
- Add total participant count on the right side of topbar. This is available on every room.

Additional:
- Remove alert confirmation when setting a user to speaker or regular participant.
- Moderator cannot set themselves to regular participant.
- When in the gallery mode, moderator cannot set anyone to speaker or regular participant. In the gallery mode, everyone is on the equal stage.