### PR TITLE
feat: event pages for early access users

### DIFF
--- a/app/(pages)/event/[eventID]/edit/page.tsx
+++ b/app/(pages)/event/[eventID]/edit/page.tsx
@@ -6,7 +6,6 @@ import { notFound } from 'next/navigation';
 import { Metadata } from 'next';
 import { eventService } from '@/(server)/api/_index';
 import HTTPError from '@/_shared/components/errors/http-error';
-import { whitelistFeature } from '@/_shared/utils/flag';
 
 type PageProps = {
   params: {
@@ -36,17 +35,6 @@ export const generateMetadata = async ({
 
   if (!event || !event.id) return null; // use not-found metadata
 
-  const eligibleForEvent =
-    whitelistFeature.includes('event') ||
-    !!user?.whitelistFeature.includes('event');
-
-  if (!eligibleForEvent) {
-    return {
-      title: `You are not eligible to see this page — inLive Room`,
-      description: 'Only early-access users can access this page.',
-    };
-  }
-
   return {
     title: `Edit ${event.name} — inLive Room`,
   };
@@ -74,21 +62,6 @@ export default async function Page({ params: { eventID } }: PageProps) {
 
   if (!event) {
     return notFound();
-  }
-
-  const eligibleForEvent =
-    whitelistFeature.includes('event') ||
-    !!user?.whitelistFeature.includes('event');
-
-  if (!eligibleForEvent) {
-    return (
-      <AppContainer user={user}>
-        <HTTPError
-          title="You are not eligible to see this page"
-          description="Only early-access users can access this page."
-        />
-      </AppContainer>
-    );
   }
 
   return (

--- a/app/(pages)/event/create/page.tsx
+++ b/app/(pages)/event/create/page.tsx
@@ -4,6 +4,7 @@ import AppContainer from '@/_shared/components/containers/app-container';
 import EventForm from '@/_features/event/components/event-form';
 import { AuthType } from '@/_shared/types/auth';
 import HTTPError from '@/_shared/components/errors/http-error';
+import { whitelistFeature } from '@/_shared/utils/flag';
 
 export const metadata: Metadata = {
   title: 'Create Your Event — inLive Room',
@@ -18,17 +19,33 @@ export default async function Page() {
       ? JSON.parse(userAuthHeader)
       : userAuthHeader;
 
+  if (!user) {
+    return (
+      <HTTPError
+        title="Login Required"
+        description="You need to be logged in to access this page"
+      />
+    );
+  }
+
+  const eligibleForEvent =
+    whitelistFeature.includes('event') ||
+    !!user?.whitelistFeature.includes('event');
+
+  if (!eligibleForEvent) {
+    return (
+      <AppContainer user={user}>
+        <HTTPError
+          title="You are not eligible to see this page"
+          description="Only early-access users can access this page."
+        />
+      </AppContainer>
+    );
+  }
+
   return (
     <AppContainer user={user}>
-      {user ? (
-        <EventForm />
-      ) : (
-        <HTTPError
-          code={403}
-          title="Login Required"
-          description="You need to be logged in to access this page"
-        />
-      )}
+      <EventForm />
     </AppContainer>
   );
 }

--- a/app/(pages)/event/create/page.tsx
+++ b/app/(pages)/event/create/page.tsx
@@ -6,8 +6,36 @@ import { AuthType } from '@/_shared/types/auth';
 import HTTPError from '@/_shared/components/errors/http-error';
 import { whitelistFeature } from '@/_shared/utils/flag';
 
-export const metadata: Metadata = {
-  title: 'Create Your Event — inLive Room',
+export const generateMetadata = (): Metadata => {
+  const headersList = headers();
+  const userAuthHeader = headersList.get('user-auth');
+
+  const user: AuthType.CurrentAuthData | null =
+    typeof userAuthHeader === 'string'
+      ? JSON.parse(userAuthHeader)
+      : userAuthHeader;
+
+  if (!user || !user.id) {
+    return {
+      title: `Login Required — inLive Room`,
+      description: 'You need to be logged in to access this page',
+    };
+  }
+
+  const eligibleForEvent =
+    whitelistFeature.includes('event') ||
+    !!user?.whitelistFeature.includes('event');
+
+  if (!eligibleForEvent) {
+    return {
+      title: `You are not eligible to see this page — inLive Room`,
+      description: 'Only early-access users can access this page.',
+    };
+  }
+
+  return {
+    title: `Create Your Event — inLive Room`,
+  };
 };
 
 export default async function Page() {

--- a/app/(pages)/event/page.tsx
+++ b/app/(pages)/event/page.tsx
@@ -6,6 +6,7 @@ import HTTPError from '@/_shared/components/errors/http-error';
 import EventList from '@/_features/event/components/event-list';
 import { EventType } from '@/_shared/types/event';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
+import { whitelistFeature } from '@/_shared/utils/flag';
 
 export const metadata: Metadata = {
   title: 'My Events — inLive Room',
@@ -19,9 +20,6 @@ export default async function Page({
   const headersList = headers();
   const userAuthHeader = headersList.get('user-auth');
 
-  const page = searchParams['page'] ? parseInt(searchParams['page']) : 1;
-  const limit = searchParams['limit'] ? parseInt(searchParams['limit']) : 10;
-
   const user: AuthType.CurrentAuthData | null =
     typeof userAuthHeader === 'string'
       ? JSON.parse(userAuthHeader)
@@ -30,12 +28,29 @@ export default async function Page({
   if (!user) {
     return (
       <HTTPError
-        code={403}
         title="Login Required"
         description="You need to be logged in to access this page"
       />
     );
   }
+
+  const eligibleForEvent =
+    whitelistFeature.includes('event') ||
+    !!user?.whitelistFeature.includes('event');
+
+  if (!eligibleForEvent) {
+    return (
+      <AppContainer user={user}>
+        <HTTPError
+          title="You are not eligible to see this page"
+          description="Only early-access users can access this page."
+        />
+      </AppContainer>
+    );
+  }
+
+  const page = searchParams['page'] ? parseInt(searchParams['page']) : 1;
+  const limit = searchParams['limit'] ? parseInt(searchParams['limit']) : 10;
 
   const eventResponse: EventType.ListEventsResponse =
     await InternalApiFetcher.get(
@@ -44,15 +59,7 @@ export default async function Page({
 
   return (
     <AppContainer user={user}>
-      {user ? (
-        <EventList events={eventResponse} />
-      ) : (
-        <HTTPError
-          code={403}
-          title="Login Required"
-          description="You need to be logged in to access this page"
-        />
-      )}
+      <EventList events={eventResponse} />
     </AppContainer>
   );
 }

--- a/app/(pages)/event/page.tsx
+++ b/app/(pages)/event/page.tsx
@@ -8,8 +8,36 @@ import { EventType } from '@/_shared/types/event';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
 import { whitelistFeature } from '@/_shared/utils/flag';
 
-export const metadata: Metadata = {
-  title: 'My Events — inLive Room',
+export const metadata = (): Metadata => {
+  const headersList = headers();
+  const userAuthHeader = headersList.get('user-auth');
+
+  const user: AuthType.CurrentAuthData | null =
+    typeof userAuthHeader === 'string'
+      ? JSON.parse(userAuthHeader)
+      : userAuthHeader;
+
+  if (!user || !user.id) {
+    return {
+      title: `Login Required — inLive Room`,
+      description: 'You need to be logged in to access this page',
+    };
+  }
+
+  const eligibleForEvent =
+    whitelistFeature.includes('event') ||
+    !!user?.whitelistFeature.includes('event');
+
+  if (!eligibleForEvent) {
+    return {
+      title: `You are not eligible to see this page — inLive Room`,
+      description: 'Only early-access users can access this page.',
+    };
+  }
+
+  return {
+    title: `My Events — inLive Room`,
+  };
 };
 
 export default async function Page({

--- a/app/(pages)/event/page.tsx
+++ b/app/(pages)/event/page.tsx
@@ -8,7 +8,7 @@ import { EventType } from '@/_shared/types/event';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
 import { whitelistFeature } from '@/_shared/utils/flag';
 
-export const metadata = (): Metadata => {
+export const generateMetadata = (): Metadata => {
   const headersList = headers();
   const userAuthHeader = headersList.get('user-auth');
 

--- a/app/_shared/components/errors/http-error.tsx
+++ b/app/_shared/components/errors/http-error.tsx
@@ -3,7 +3,7 @@ import Header from '@/_shared/components/header/header';
 import Footer from '@/_shared/components/footer/footer';
 
 type HTTPErrorProps = {
-  code: number;
+  code?: number;
   title: string;
   description: string;
 };
@@ -19,9 +19,11 @@ export default function HTTPError({
         <Header logoText="inLive Room" logoHref="/" />
         <main className="mx-auto flex flex-1 flex-col justify-center">
           <div className="flex items-center gap-5">
-            <div>
-              <b className="block text-2xl">{code}</b>
-            </div>
+            {code && (
+              <div>
+                <b className="block text-2xl">{code}</b>
+              </div>
+            )}
             <div>
               <b className="block text-base font-medium">{title}</b>
               <p className="mt-0.5 block text-sm text-neutral-400">

--- a/app/_shared/components/header/profile.tsx
+++ b/app/_shared/components/header/profile.tsx
@@ -32,7 +32,7 @@ export default function Profile() {
   const onProfileSelection = useCallback(
     async (selectedKey: Key) => {
       switch (selectedKey) {
-        case 'myevent':
+        case 'my-events':
           if (!eligibleForEvent) return;
 
           navigateTo(new URL(`/event`, window.location.origin).href);
@@ -62,7 +62,7 @@ export default function Profile() {
   const disabledKeys = ['profile'];
 
   if (!eligibleForEvent) {
-    disabledKeys.push('myevent');
+    disabledKeys.push('my-events');
   }
 
   return (
@@ -129,9 +129,9 @@ export default function Profile() {
                 </div>
               </DropdownItem>
             </DropdownSection>
-            <DropdownItem key="myevent" textValue="myevent">
+            <DropdownItem key="my-events" textValue="my-events">
               <div className="flex justify-between text-sm font-medium text-zinc-200">
-                <span className="inline-block">My Event</span>
+                <span className="inline-block">My Events</span>
                 {!whitelistFeature.includes('event') && (
                   <span className="inline-flex items-center rounded-sm border border-emerald-800 bg-emerald-950 px-1 text-[10px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
                     Limited Beta


### PR DESCRIPTION
## Changelogs
- My Events menu will display "Limited Beta" when the webinar is only enabled for specific users. For users who are part of early access, the menu is disabled.
-  When the webinar is only enabled for specific users, only early access users will be able to access `/event` page. The metadata was also adjusted and updated.
- When the webinar is only enabled for specific users, only early access users will be able to access `/event/create` page. The metadata was also adjusted and updated.
- Ensure `/event`, `/event/create`, and `/event/{id}/edit` pages are only accessible for logged in users.
- Updated the `/event/{id}/edit` metadata