### PR TITLE
fix: remove limiting the webinar access to some pages

### DIFF
--- a/app/(pages)/past-events/page.tsx
+++ b/app/(pages)/past-events/page.tsx
@@ -3,7 +3,6 @@ import { cookies, headers } from 'next/headers';
 import AppContainer from '@/_shared/components/containers/app-container';
 import type { AuthType } from '@/_shared/types/auth';
 import HTTPError from '@/_shared/components/errors/http-error';
-import { whitelistFeature } from '@/_shared/utils/flag';
 import PastEvents from '@/_features/event/components/event-stat-list';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
 import { EventType } from '@/_shared/types/event';
@@ -23,17 +22,6 @@ export const generateMetadata = (): Metadata => {
     return {
       title: `Login Required — inLive Room`,
       description: 'You need to be logged in to access this page',
-    };
-  }
-
-  const eligibleForEvent =
-    whitelistFeature.includes('event') ||
-    !!user?.whitelistFeature.includes('event');
-
-  if (!eligibleForEvent) {
-    return {
-      title: `You are not eligible to see this page — inLive Room`,
-      description: 'Only early-access users can access this page.',
     };
   }
 
@@ -61,21 +49,6 @@ export default async function Page({
         title="Login Required"
         description="You need to be logged in to access this page"
       />
-    );
-  }
-
-  const eligibleForEvent =
-    whitelistFeature.includes('event') ||
-    !!user?.whitelistFeature.includes('event');
-
-  if (!eligibleForEvent) {
-    return (
-      <AppContainer user={user}>
-        <HTTPError
-          title="You are not eligible to see this page"
-          description="Only early-access users can access this page."
-        />
-      </AppContainer>
     );
   }
 

--- a/app/_features/home/create-room.tsx
+++ b/app/_features/home/create-room.tsx
@@ -15,13 +15,8 @@ import { useState } from 'react';
 import { Mixpanel } from '@/_shared/components/analytics/mixpanel';
 import type { RoomType } from '@/_shared/types/room';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
-import { whitelistFeature } from '@/_shared/utils/flag';
 
-export default function CreateRoom({
-  setWebinarAlertActive,
-}: {
-  setWebinarAlertActive: () => void;
-}) {
+export default function CreateRoom() {
   const { user } = useAuthContext();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -57,15 +52,6 @@ export default function CreateRoom({
     async (key: Key) => {
       if (!user || isSubmitting || typeof key !== 'string') return;
 
-      if (
-        key === 'event' &&
-        !whitelistFeature.includes('event') &&
-        !user?.whitelistFeature.includes('event')
-      ) {
-        setWebinarAlertActive();
-        return;
-      }
-
       setIsSubmitting(true);
 
       try {
@@ -84,7 +70,7 @@ export default function CreateRoom({
         console.error(error);
       }
     },
-    [user, isSubmitting, createRoom, setWebinarAlertActive]
+    [user, isSubmitting, createRoom]
   );
 
   return (
@@ -152,11 +138,6 @@ export default function CreateRoom({
               >
                 <div className="flex justify-between text-sm font-medium text-zinc-200">
                   <span className="inline-block">Webinar</span>
-                  {!whitelistFeature.includes('event') && (
-                    <span className="inline-flex items-center rounded-sm border border-emerald-800 bg-emerald-950 px-1.5 text-[11px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
-                      Limited Beta
-                    </span>
-                  )}
                 </div>
                 <div className="text-xs text-zinc-400 group-hover:text-zinc-200">
                   Host sessions with large audiences

--- a/app/_features/home/home.tsx
+++ b/app/_features/home/home.tsx
@@ -3,31 +3,8 @@ import Header from '@/_shared/components/header/header';
 import CreateRoom from '@/_features/home/create-room';
 import JoinRoom from '@/_features/home/join-room';
 import Footer from '@/_shared/components/footer/footer';
-import { whitelistFeature } from '@/_shared/utils/flag';
-import { useAuthContext } from '@/_shared/contexts/auth';
-import { useToggle } from '@/_shared/hooks/use-toggle';
-
-const WebinarBetaAlert = () => {
-  return (
-    <div className="mx-auto max-w-3xl rounded-2xl bg-blue-900/25 p-5 text-sm text-blue-300">
-      <p className="text-pretty">
-        Heads up! The webinar feature is currently in beta with limited early
-        access.
-      </p>
-      <p className="mt-5 text-pretty">
-        Be among the first to try it! Earn your access by attend webinars for a
-        total of 60 minutes, it can be spread across multiple sessions. Just
-        remember to log in first before attending.
-      </p>
-    </div>
-  );
-};
 
 export default function View() {
-  const { user } = useAuthContext();
-  const { active: webinarAlertActive, setActive: setWebinarAlertActive } =
-    useToggle(false);
-
   return (
     <div className="bg-zinc-900 text-zinc-200">
       <div className="min-viewport-height mx-auto flex h-full w-full max-w-5xl flex-1 flex-col  px-4">
@@ -35,26 +12,12 @@ export default function View() {
         <main className="flex flex-1 flex-col justify-center">
           <div className="flex w-full flex-col gap-10 py-10 md:flex-row md:py-20 lg:gap-20">
             <div>
-              <CreateRoom setWebinarAlertActive={setWebinarAlertActive} />
-              {!whitelistFeature.includes('event') &&
-                !user?.whitelistFeature.includes('event') &&
-                webinarAlertActive && (
-                  <div className="mt-10 block md:hidden">
-                    <WebinarBetaAlert />
-                  </div>
-                )}
+              <CreateRoom />
             </div>
             <div className="mx-auto w-full max-w-[400px] md:max-w-[360px] lg:max-w-[400px]">
               <JoinRoom />
             </div>
           </div>
-          {!whitelistFeature.includes('event') &&
-            !user?.whitelistFeature.includes('event') &&
-            webinarAlertActive && (
-              <div className="hidden md:block">
-                <WebinarBetaAlert />
-              </div>
-            )}
         </main>
         <Footer />
       </div>

--- a/app/_shared/components/header/profile.tsx
+++ b/app/_shared/components/header/profile.tsx
@@ -15,7 +15,6 @@ import { useAuthContext } from '@/_shared/contexts/auth';
 import ArrowDownFillIcon from '@/_shared/components/icons/arrow-down-fill-icon';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
 import { useNavigate } from '@/_shared/hooks/use-navigate';
-import { whitelistFeature } from '@/_shared/utils/flag';
 
 export default function Profile() {
   const { user, setUser } = useAuthContext();
@@ -25,23 +24,18 @@ export default function Profile() {
     document.dispatchEvent(new CustomEvent('open:sign-in-modal'));
   };
 
-  const eligibleForEvent =
-    whitelistFeature.includes('event') ||
-    !!user?.whitelistFeature.includes('event');
-
   const onProfileSelection = useCallback(
     async (selectedKey: Key) => {
       switch (selectedKey) {
         case 'my-events':
-          if (!eligibleForEvent) return;
-
-          navigateTo(new URL(`/event`, window.location.origin).href);
+          navigateTo(`/event`);
           break;
         case 'signout':
           {
             try {
               await InternalApiFetcher.get('/api/auth/signout');
               setUser(null);
+              window.location.reload();
             } catch (error) {
               console.error(error);
               Sentry.captureException(error, {
@@ -56,14 +50,8 @@ export default function Profile() {
           break;
       }
     },
-    [navigateTo, setUser, eligibleForEvent]
+    [navigateTo, setUser]
   );
-
-  const disabledKeys = ['profile'];
-
-  if (!eligibleForEvent) {
-    disabledKeys.push('my-events');
-  }
 
   return (
     <>
@@ -96,7 +84,6 @@ export default function Profile() {
             disallowEmptySelection
             aria-label="Profile menu"
             onAction={onProfileSelection}
-            disabledKeys={disabledKeys}
           >
             <DropdownSection aria-label="Profile information" showDivider>
               <DropdownItem
@@ -130,14 +117,7 @@ export default function Profile() {
               </DropdownItem>
             </DropdownSection>
             <DropdownItem key="my-events" textValue="my-events">
-              <div className="flex justify-between text-sm font-medium text-zinc-200">
-                <span className="inline-block">My Events</span>
-                {!whitelistFeature.includes('event') && (
-                  <span className="inline-flex items-center rounded-sm border border-emerald-800 bg-emerald-950 px-1 text-[10px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
-                    Limited Beta
-                  </span>
-                )}
-              </div>
+              My Events
             </DropdownItem>
             <DropdownItem key="signout" textValue="signout">
               Sign Out


### PR DESCRIPTION
## Changelogs
- My event navigation link is not restricted by beta
- Remove restriction on creating the webinar room from the homepage.
- Remove alert information about webinar with limited early access