### PR TITLE
revert: revert displaying create webinar room option

### DIFF
--- a/app/_features/home/create-room.tsx
+++ b/app/_features/home/create-room.tsx
@@ -130,6 +130,24 @@ export default function CreateRoom() {
                   Personal or group meetings
                 </div>
               </DropdownItem>
+              <DropdownItem
+                key="event"
+                classNames={{
+                  wrapper: 'group',
+                }}
+              >
+                <div className="flex justify-between text-sm font-medium text-zinc-200">
+                  <span className="inline-block">Webinar</span>
+                  <div className="inline-flex items-center">
+                    <span className="rounded-sm border-1 border-emerald-800 bg-emerald-950 px-1.5 text-[11px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
+                      Beta
+                    </span>
+                  </div>
+                </div>
+                <div className="text-xs text-zinc-400 group-hover:text-zinc-200">
+                  Host sessions with large audiences
+                </div>
+              </DropdownItem>
             </DropdownMenu>
           </Dropdown>
         ) : (

--- a/app/_shared/components/header/profile.tsx
+++ b/app/_shared/components/header/profile.tsx
@@ -119,8 +119,10 @@ export default function Profile() {
             <DropdownItem key="my-events" textValue="my-events">
               <div className="flex justify-between text-sm font-medium text-zinc-200">
                 <span className="inline-block">My Events</span>
-                <div className="rounded-sm border-1 border-emerald-800 bg-emerald-950 px-2 py-[1px] text-[10px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
-                  Beta
+                <div className="inline-flex items-center">
+                  <span className="rounded-sm border-1 border-emerald-800 bg-emerald-950 px-1.5 text-[11px] font-medium leading-4 tracking-[0.275px] text-emerald-300">
+                    Beta
+                  </span>
                 </div>
               </div>
             </DropdownItem>


### PR DESCRIPTION
This PR will revert and display the create webinar room option when the user triggers the create room dropdown again after being removed previously. It also displaying the beta info again besides the create webinar room option.