### PR TITLE
feat: endpoint to get registered participants

### DIFF
--- a/app/(server)/_features/event/repository.ts
+++ b/app/(server)/_features/event/repository.ts
@@ -242,10 +242,11 @@ export class EventRepo implements iEventRepo {
     const res = await db.transaction(async (tx) => {
       const registeree = await tx
         .select({
-          firstName: participants.firstName,
-          lastName: participants.lastName,
+          first_name: participants.firstName,
+          last_name: participants.lastName,
           email: participants.email,
           id: participants.id,
+          created_at: participants.createdAt,
         })
         .from(eventHasParticipant)
         .innerJoin(events, eq(eventHasParticipant.eventId, events.id))

--- a/app/(server)/api/events/[slugOrId]/details/registeree/route.ts
+++ b/app/(server)/api/events/[slugOrId]/details/registeree/route.ts
@@ -11,6 +11,9 @@ export async function GET(
   const slugOrId = params.slugOrId;
   const cookieStore = cookies();
   const requestToken = cookieStore.get('token');
+  const { searchParams } = new URL(request.url);
+  const page = parseInt(searchParams.get('page') ?? '1');
+  const limit = parseInt(searchParams.get('limit') ?? '10');
 
   try {
     if (!requestToken) {
@@ -36,18 +39,12 @@ export async function GET(
       );
     }
 
-    const res = await eventRepo.getRegisteredParticipants(slugOrId, user.id);
-
-    if (res.data.length === 0) {
-      return NextResponse.json(
-        {
-          code: 404,
-          message: 'not found',
-          ok: false,
-        },
-        { status: 404 }
-      );
-    }
+    const res = await eventRepo.getRegisteredParticipants(
+      slugOrId,
+      user.id,
+      limit,
+      page
+    );
 
     return NextResponse.json(
       {

--- a/app/(server)/api/events/[slugOrId]/details/registeree/route.ts
+++ b/app/(server)/api/events/[slugOrId]/details/registeree/route.ts
@@ -1,0 +1,72 @@
+import { getCurrentAuthenticated } from '@/(server)/_shared/utils/get-current-authenticated';
+import { eventRepo } from '@/(server)/api/_index';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import * as Sentry from '@sentry/nextjs';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { slugOrId: string } }
+) {
+  const slugOrId = params.slugOrId;
+  const cookieStore = cookies();
+  const requestToken = cookieStore.get('token');
+
+  try {
+    if (!requestToken) {
+      return NextResponse.json(
+        {
+          code: 401,
+          message: 'please check your authentication token',
+        },
+        { status: 401 }
+      );
+    }
+
+    const response = await getCurrentAuthenticated(requestToken?.value);
+    const user = response.data ? response.data : null;
+
+    if (!user) {
+      return NextResponse.json(
+        {
+          code: 401,
+          message: 'unauthorized',
+        },
+        { status: 401 }
+      );
+    }
+
+    const res = await eventRepo.getRegisteredParticipants(slugOrId, user.id);
+
+    if (res.data.length === 0) {
+      return NextResponse.json(
+        {
+          code: 404,
+          message: 'not found',
+          ok: false,
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json(
+      {
+        data: res.data,
+        meta: res.meta,
+        message: 'success',
+        ok: true,
+      },
+      { status: 200 }
+    );
+  } catch (e) {
+    Sentry.captureException(e);
+    return NextResponse.json(
+      {
+        code: 500,
+        message: 'internal server error',
+        ok: false,
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Created endpoint `GET` `/api/events/:id/details/registerees`

Represent the Count & List of registered participants on a particular event. The endpoint is only available to the event creator. A registeree is added when a user register to an event.

[Response Detail](https://docs.google.com/document/d/1SkyQl1-p1S08y0TTXBc62J8POUg98dRPjOo9WkA3EOI/edit)