### PR TITLE
fix: fixing NaN percentage value on past events stat

### DIFF
--- a/app/(server)/api/events/[slugOrId]/stat/route.ts
+++ b/app/(server)/api/events/[slugOrId]/stat/route.ts
@@ -84,9 +84,14 @@ export async function GET(
     ).value;
     const countUser = (await countJoinedUser(existingEvent.roomId)).value;
     const countGuest = (await countJoinedGuest(existingEvent.roomId)).value;
+    const totalJoined = countGuest + countUser;
+
     const percentageJoined =
-      ((countGuest + countUser) / countRegistirees) * 100;
-    const percentageGuest = (countGuest / (countGuest + countUser)) * 100;
+      totalJoined > 0 && countRegistirees > 0
+        ? (totalJoined / countRegistirees) * 100
+        : 0;
+    const percentageGuest =
+      countGuest > 0 && totalJoined > 0 ? (countGuest / totalJoined) * 100 : 0;
 
     return NextResponse.json({
       code: 200,
@@ -94,8 +99,9 @@ export async function GET(
         registeredUsers: countRegistirees || 0,
         joinedUsers: countUser || 0,
         joinedGuests: countGuest || 0,
-        percentageJoined: percentageJoined.toFixed(2) || 0,
-        percentageGuest: percentageGuest.toFixed(2) || 0,
+        percentageJoined:
+          percentageJoined > 0 ? percentageJoined.toFixed(2) : 0,
+        percentageGuest: percentageGuest > 0 ? percentageGuest.toFixed(2) : 0,
       },
     });
   } catch (error) {

--- a/app/_features/event/components/event-list.tsx
+++ b/app/_features/event/components/event-list.tsx
@@ -23,6 +23,10 @@ const navLinks = [
     title: 'My Events',
     href: '/events',
   },
+  {
+    title: 'Past Events',
+    href: '/past-events',
+  },
 ];
 
 export default function EventList({

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -4,7 +4,6 @@ import { EventType } from '@/_shared/types/event';
 import { selectEvent } from '@/(server)/_features/event/schema';
 import { useEffect, useState } from 'react';
 import { InternalApiFetcher } from '@/_shared/utils/fetcher';
-import { Link } from '@nextui-org/react';
 
 export function EventStatCard({ event }: { event: selectEvent }) {
   const APP_ORIGIN = process.env.NEXT_PUBLIC_APP_ORIGIN;
@@ -40,10 +39,7 @@ export function EventStatCard({ event }: { event: selectEvent }) {
 
   return (
     <li>
-      <Link
-        href={`/events/${event.slug}/stat`}
-        className="flex flex-col gap-4 rounded-3xl border border-zinc-800 p-5 px-4 hover:bg-zinc-800/50 active:bg-zinc-800 sm:p-5"
-      >
+      <div className="flex flex-col gap-4 rounded-3xl border border-zinc-800 p-5 px-4 sm:p-5">
         {/* Header */}
         <div className="flex w-full flex-col gap-5 sm:flex-row sm:justify-between">
           <div className="max-w-none sm:order-2 sm:max-w-60 md:max-w-40">
@@ -116,7 +112,7 @@ export function EventStatCard({ event }: { event: selectEvent }) {
             </div>
           )}
         </div>
-      </Link>
+      </div>
     </li>
   );
 }

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -100,11 +100,11 @@ export function EventStatCard({ event }: { event: selectEvent }) {
                 />
                 <StatItem
                   name="Percentage joined"
-                  value={stat.data.percentageJoined}
+                  value={`${stat.data.percentageJoined}%`}
                 />
                 <StatItem
                   name="Percentage guest"
-                  value={stat.data.percentageGuest}
+                  value={`${stat.data.percentageGuest}%`}
                 />
               </StatList>
             </>


### PR DESCRIPTION
## Changelogs
- NaN percentage value will be considered as zero percentage
- Display postfix percentage symbol
- Past events page navigation link now accessible from my events page
- Remove link to detail page of each past event card for now.