### PR TITLE
feat: new page to show past-event detail

### DIFF
--- a/app/(pages)/past-events/[eventID]/page.tsx
+++ b/app/(pages)/past-events/[eventID]/page.tsx
@@ -3,6 +3,7 @@ import EventPastDashboard from '@/_features/event/components/event-past-dashboar
 import AppContainer from '@/_shared/components/containers/app-container';
 import HTTPError from '@/_shared/components/errors/http-error';
 import { AuthType } from '@/_shared/types/auth';
+import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
 
 type PageProps = {

--- a/app/(pages)/past-events/[eventID]/page.tsx
+++ b/app/(pages)/past-events/[eventID]/page.tsx
@@ -1,0 +1,55 @@
+import { eventService } from '@/(server)/api/_index';
+import EventPastDashboard from '@/_features/event/components/event-past-dashboard';
+import AppContainer from '@/_shared/components/containers/app-container';
+import HTTPError from '@/_shared/components/errors/http-error';
+import { AuthType } from '@/_shared/types/auth';
+import { notFound } from 'next/navigation';
+
+type PageProps = {
+  params: {
+    eventID: string;
+  };
+};
+export default async function Page({ params: { eventID } }: PageProps) {
+  const headersList = headers();
+  const userAuthHeader = headersList.get('user-auth');
+
+  const user: AuthType.CurrentAuthData | null =
+    typeof userAuthHeader === 'string'
+      ? JSON.parse(userAuthHeader)
+      : userAuthHeader;
+
+  if (!user || !user.id) {
+    return (
+      <AppContainer user={user}>
+        <HTTPError
+          code={401}
+          title="Login Required"
+          description="You need to be logged in to access this page"
+        />
+      </AppContainer>
+    );
+  }
+
+  const event = await eventService.getEventBySlugOrID(eventID, user.id);
+
+  if (!event) {
+    return notFound();
+  }
+
+  const isHost = user.id === event.createdBy;
+
+  if (!isHost) {
+    return (
+      <AppContainer user={user}>
+        <HTTPError
+          code={403}
+          title="You are not authorized"
+          description="You don't have permission to access this page. Please use an account which has access to this page."
+        />
+      </AppContainer>
+    );
+  }
+
+  return <EventPastDashboard event={event} />;
+}

--- a/app/(server)/api/events/[slugOrId]/stat/route.ts
+++ b/app/(server)/api/events/[slugOrId]/stat/route.ts
@@ -93,7 +93,7 @@ export async function GET(
     const registeredAttendance =
       await eventRepo.getParticipantAttendancePercentage(existingEvent?.id);
 
-    const data: EventType.Stat['data'] = {
+    const data: EventType.GetStatsResponse['data'] = {
       count: {
         registeree: countRegistirees || 0,
 

--- a/app/_features/event/components/event-past-dashboard.tsx
+++ b/app/_features/event/components/event-past-dashboard.tsx
@@ -1,0 +1,375 @@
+'use client';
+
+import Header from '@/_shared/components/header/header';
+import { EventType } from '@/_shared/types/event';
+import { Button, Image, Tab, Tabs, Tooltip } from '@nextui-org/react';
+import Link from 'next/link';
+import { StatusPublished, StatusCancelled } from './event-status';
+import { useFormattedDateTime } from '@/_shared/hooks/use-formatted-datetime';
+import InfoIcon from '@/_shared/components/icons/info-icon';
+import { InternalApiFetcher } from '@/_shared/utils/fetcher';
+import { useCallback, useEffect, useState } from 'react';
+import ChevronLeft from '@/_shared/components/icons/chevron-left';
+import ChevronRight from '@/_shared/components/icons/chevron-right';
+import { EventStatCard } from './event-stat-card';
+import Footer from '@/_shared/components/footer/footer';
+
+const APP_ORIGIN = process.env.NEXT_PUBLIC_APP_ORIGIN;
+export default function EventPastDashboard({
+  event,
+}: {
+  event: EventType.Event;
+}) {
+  const thumbnailUrl = event.thumbnailUrl
+    ? `${APP_ORIGIN}/static${event.thumbnailUrl}`
+    : '/images/webinar/webinar-no-image-placeholder.png';
+
+  const startDate = useFormattedDateTime(event.startTime, 'en-GB', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  const startTime = useFormattedDateTime(event.startTime, 'en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  const endTime = useFormattedDateTime(event.endTime, 'en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+
+  const durationString = getDurationString(event.startTime, event.endTime);
+
+  const createdDate = useFormattedDateTime(event.createdAt, 'en-GB', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="bg-zinc-900">
+      <div className="min-viewport-height mx-auto flex max-w-7xl flex-col px-4">
+        <Header logoText="inLive Room" logoHref="/" />
+        <main>
+          {/*  */}
+          <div>
+            <Button
+              as={Link}
+              href="/past-events"
+              className="inline-flex min-w-0 gap-2 rounded-lg bg-transparent py-2 pl-3 pr-4  antialiased hover:bg-zinc-800 active:bg-zinc-700"
+            >
+              <span>
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-5 w-5 lg:h-6 lg:w-6"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    fill="none"
+                    stroke="currentColor"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M5 12h14M5 12l6 6m-6-6l6-6"
+                  />
+                </svg>
+              </span>
+              <span className="text-sm font-medium text-white lg:text-base">
+                Back to past event list
+              </span>
+            </Button>
+          </div>
+          <div className="lg:px-5">
+            <div className="border-b border-zinc-800 py-4 lg:py-6">
+              <div className="mb-3 flex items-center md:-mb-5">
+                {event.status === 'published' && <StatusPublished />}
+                {event.status === 'cancelled' && <StatusCancelled />}
+                <span className="ml-3 inline-block text-sm font-medium text-zinc-500">
+                  Free event
+                </span>
+              </div>
+              <div className="flex flex-col gap-2 md:flex-row md:justify-between md:gap-5">
+                <div className="md:order-2">
+                  <Image
+                    referrerPolicy="no-referrer"
+                    src={thumbnailUrl}
+                    alt={`Thumbnail image of ${event.name}`}
+                    loading="lazy"
+                    width={160}
+                    height={80}
+                    className="rounded object-cover"
+                  />
+                </div>
+                <div className="md:order-1 md:flex-1 md:pt-7">
+                  <h3 className="text-base font-medium text-zinc-300 lg:text-lg">
+                    {event.name}
+                  </h3>
+                  <span className="mt-2 inline-block text-sm font-medium text-zinc-500">
+                    <span>{startDate}</span>,&nbsp;
+                    <span className="lowercase">
+                      {startTime} - {endTime}
+                    </span>
+                    ,&nbsp;
+                    <span>
+                      <span className="text-zinc-400"> ({durationString})</span>
+                    </span>
+                  </span>
+                </div>
+              </div>
+            </div>
+            <div className="flex flex-col gap-1 py-3 sm:flex-row sm:gap-8 lg:py-5">
+              <div className="text-sm font-medium text-zinc-400">
+                Created on {createdDate}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-4 pt-2.5 lg:mt-2 lg:px-5 lg:pt-2">
+            <div className="relative mt-4 block  overflow-auto">
+              <Tabs
+                key={'underlined'}
+                variant={'underlined'}
+                aria-label="tab"
+                classNames={{
+                  base: 'w-full',
+                  tabList:
+                    'gap-6 w-full relative rounded-none p-0 border-b border-divider',
+                  cursor: 'w-full',
+                  tab: 'max-w-fit px-0 h-12',
+                }}
+              >
+                <Tab title={'Participants'}>
+                  <ParticipantTable eventID={event.id} />
+                </Tab>
+                <Tab title={'Overview'} className="overflow-y-auto">
+                  <EventStatCard
+                    showEvent={false}
+                    event={event}
+                    showButton={false}
+                  ></EventStatCard>
+                </Tab>
+              </Tabs>
+            </div>
+          </div>
+        </main>
+        <Footer />
+      </div>
+    </div>
+  );
+}
+
+function ParticipantTable({ eventID }: { eventID: string | number }) {
+  const [isPending, setIsPending] = useState(true);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(10);
+  const [participants, setParticipants] = useState<
+    EventType.GetParticipantsResponse | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const fetchParticipants = async () => {
+      InternalApiFetcher.get(
+        `/api/events/${eventID}/details/participants?limit=${limit}&page=${page}`
+      ).then((res) => {
+        setParticipants(res);
+        setIsPending(false);
+      });
+    };
+
+    fetchParticipants();
+    console.log();
+  }, [eventID, limit, page]);
+
+  useEffect(() => {
+    console.log(participants);
+  }, [participants]);
+
+  const nextPage = useCallback(() => {
+    setPage((prev) => prev + 1);
+  }, []);
+
+  const previousPage = useCallback(() => {
+    setPage((prev) => prev - 1);
+  }, []);
+
+  return (
+    <div
+      className="max-h-[400px]
+    overscroll-contain"
+    >
+      {isPending ? (
+        <div className="flex items-center justify-center p-3 text-zinc-200 lg:p-6">
+          Loading...
+        </div>
+      ) : !participants ? (
+        <div className="flex items-center justify-center p-3 text-zinc-200 lg:p-6">
+          Failed to fetch data
+        </div>
+      ) : (
+        <div className="overflow-x-hidden">
+          <div className="flex w-full flex-row items-center justify-end gap-2 py-2">
+            <span className="text-sm text-zinc-300">
+              Showing{' '}
+              {participants.meta.per_page *
+                (participants.meta.current_page - 1) +
+                1}{' '}
+              -{' '}
+              {participants.meta.per_page * participants.meta.current_page >
+              participants.meta.total_record
+                ? participants.meta.total_record
+                : participants.meta.per_page * participants.meta.current_page}
+            </span>
+            <Button
+              isIconOnly
+              onClick={previousPage}
+              isDisabled={page <= 1}
+              size="sm"
+            >
+              <ChevronLeft height={20} width={20} />
+            </Button>
+            <Button
+              size="sm"
+              onClick={nextPage}
+              isIconOnly
+              isDisabled={page >= participants.meta.total_page}
+            >
+              <ChevronRight height={20} width={20} />
+            </Button>
+          </div>
+          <div className="w-full overflow-x-scroll">
+            <table className="w-full table-auto divide-y divide-zinc-700 overflow-x-scroll text-left">
+              <thead className="sticky top-0 bg-zinc-800 leading-5 text-zinc-300">
+                <tr>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
+                  >
+                    Name
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
+                  >
+                    Email
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
+                  >
+                    Register
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
+                  >
+                    Join
+                  </th>
+                  <th
+                    scope="col"
+                    className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
+                  >
+                    Attend
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-700 text-sm">
+                {participants.data.length > 0 ? (
+                  participants.data.map((participant) => {
+                    return (
+                      <ParticipantItem
+                        key={participant.clientID}
+                        participant={participant}
+                      />
+                    );
+                  })
+                ) : (
+                  <tr>
+                    <td colSpan={3}>
+                      <div className="flex items-center justify-center p-3 text-zinc-200 lg:p-6">
+                        Empty data
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function getDurationString(startTime: Date, endTime: Date) {
+  const duration = Math.abs(endTime.getTime() - startTime.getTime()); // Ensure duration is positive
+  const hours = Math.floor(duration / 3600000); // Convert milliseconds to hours
+  const minutes = Math.floor((duration % 3600000) / 60000); // Convert the remaining milliseconds to minutes
+  const seconds = Math.floor((duration % 60000) / 1000); // Convert the remaining milliseconds to seconds
+
+  let durationString = '';
+  if (hours > 0) {
+    durationString += `${hours} Hour `;
+  }
+  if (minutes > 0 || hours > 0) {
+    // Include minutes if there are hours or minutes
+    durationString += `${minutes} Minutes `;
+  }
+  durationString += `${seconds} Seconds`;
+
+  return durationString;
+}
+
+function ParticipantItem({
+  participant,
+}: {
+  participant: EventType.EventParticipant;
+}) {
+  return (
+    <tr>
+      <th
+        scope="row"
+        className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 font-medium text-zinc-200 lg:p-6"
+      >
+        {participant.name}
+      </th>
+      <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
+        {participant.email}
+      </td>
+      <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
+        <BooleanItem isTrue={participant.isRegistered}></BooleanItem>
+      </td>
+      <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
+        <BooleanItem isTrue={participant.isJoined}></BooleanItem>
+      </td>
+      <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
+        {participant.isRegistered ? (
+          BooleanItem({ isTrue: participant.isAttended || false })
+        ) : (
+          <Tooltip content="Attendance for Guests Coming Soon">
+            <Button
+              isIconOnly
+              size="sm"
+              className="bg-zinc-900  ring-1 ring-zinc-800 hover:bg-zinc-900"
+            >
+              <InfoIcon className="stroke-zinc-300" />
+            </Button>
+          </Tooltip>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function BooleanItem({ isTrue }: { isTrue: boolean }) {
+  return (
+    <div className="flex h-fit w-fit gap-2 rounded-md px-2 py-1 ring-1 ring-zinc-800">
+      <span className={isTrue ? 'text-green-800' : 'text-red-800'}>•</span>
+
+      {isTrue ? 'Yes' : 'No'}
+    </div>
+  );
+}

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -141,16 +141,16 @@ export function EventStatCard({
                   } %`}
                 />
                 <StatItem
-                  name="Percentage Joined from Total Participants"
+                  name="Percentage Registered & Joined with Total Participants"
                   value={`${stat.data.percentage.registeredCountJoin || 0} %`}
                 ></StatItem>
                 <StatItem
-                  name="Percentage Joined as Guest"
+                  name="Percentage Joined as Guest with Total Participant"
                   value={`${stat.data.percentage.guestCountJoin || 0} %`}
                 />
 
                 <StatItem
-                  name="Percentage Registered Attendances with Total Participants"
+                  name="Percentage Registered & Attendded with Total Participants"
                   value={`${
                     stat.data.percentage.registeredAttendCountJoin || 0
                   } %`}

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -8,10 +8,20 @@ import { useFormattedDateTime } from '@/_shared/hooks/use-formatted-datetime';
 import { Button, Tooltip } from '@nextui-org/react';
 import InfoIcon from '@/_shared/components/icons/info-icon';
 
-export function EventStatCard({ event }: { event: selectEvent }) {
+export function EventStatCard({
+  event,
+  showEvent = true,
+  showButton = true,
+}: {
+  event: selectEvent;
+  showEvent: boolean;
+  showButton: boolean;
+}) {
   const APP_ORIGIN = process.env.NEXT_PUBLIC_APP_ORIGIN;
 
-  const [stat, setStat] = useState<undefined | EventType.Stat>(undefined);
+  const [stat, setStat] = useState<undefined | EventType.GetStatsResponse>(
+    undefined
+  );
   const [isPending, setIsPending] = useState(false);
 
   useEffect(() => {
@@ -23,7 +33,7 @@ export function EventStatCard({ event }: { event: selectEvent }) {
 
       InternalApiFetcher.get(`/api/events/${event.id}/stat`, {
         method: 'GET',
-      }).then((stat: EventType.Stat) => {
+      }).then((stat: EventType.GetStatsResponse) => {
         setStat(stat);
         setIsPending(false);
       });
@@ -45,39 +55,53 @@ export function EventStatCard({ event }: { event: selectEvent }) {
   });
 
   return (
-    <li>
-      <div className="flex flex-col gap-4 rounded-3xl border border-zinc-800 p-5 px-4 sm:p-5">
+    <div>
+      <div
+        className={`flex flex-col gap-4 ${
+          showEvent ? 'rounded-3xl border border-zinc-800 p-5 px-4 sm:p-5' : ''
+        } `}
+      >
         {/* Header */}
-        <div className="flex w-full flex-col gap-5 sm:flex-row sm:justify-between">
-          <div className="max-w-none sm:order-2 sm:max-w-60 md:max-w-40">
-            <Image
-              referrerPolicy="no-referrer"
-              src={
-                event.thumbnailUrl
-                  ? `${APP_ORIGIN}/static${event.thumbnailUrl}`
-                  : '/images/webinar/webinar-no-image-placeholder.png'
-              }
-              alt={`Thumbnail image of `}
-              loading="lazy"
-              width={160}
-              height={80}
-              style={{ objectFit: 'cover' }}
-              className="w-full rounded"
-              unoptimized
-            />
-          </div>
-          <div className="flex flex-col justify-between sm:order-1">
-            <h3 className="text-lg font-medium text-zinc-300">{event.name}</h3>
-            <div className="mt-1">
-              <span className="text-sm font-medium text-zinc-500">
-                <span>{eventDate}</span>,&nbsp;
-                <span className="lowercase">{eventTime}</span>
-              </span>
+        {showEvent && (
+          <div className="flex w-full flex-col gap-5 sm:flex-row sm:justify-between">
+            <div className="max-w-none sm:order-2 sm:max-w-60 md:max-w-40">
+              <Image
+                referrerPolicy="no-referrer"
+                src={
+                  event.thumbnailUrl
+                    ? `${APP_ORIGIN}/static${event.thumbnailUrl}`
+                    : '/images/webinar/webinar-no-image-placeholder.png'
+                }
+                alt={`Thumbnail image of `}
+                loading="lazy"
+                width={160}
+                height={80}
+                style={{ objectFit: 'cover' }}
+                className="w-full rounded"
+                unoptimized
+              />
+            </div>
+            <div className="flex flex-col justify-between sm:order-1">
+              <h3 className="text-lg font-medium text-zinc-300">
+                {event.name}
+              </h3>
+              <div className="mt-1">
+                <span className="text-sm font-medium text-zinc-500">
+                  <span>{eventDate}</span>,&nbsp;
+                  <span className="lowercase">{eventTime}</span>
+                </span>
+              </div>
             </div>
           </div>
-        </div>
+        )}
+
         {/* Content */}
-        <div className="w-full border-t border-zinc-800 pb-2 pt-4">
+        <div
+          className={`w-full ${
+            showEvent ? 'border-t' : ''
+          } border-zinc-800 pb-2 pt-4`}
+        >
+          {' '}
           {isPending ? (
             <div className="text-center">
               <span className="text-sm font-medium text-zinc-500">
@@ -148,8 +172,18 @@ export function EventStatCard({ event }: { event: selectEvent }) {
             </div>
           )}
         </div>
+
+        {showButton && (
+          <div className="start-end flex w-full border-t border-zinc-700 pb-6 pt-4">
+            <Button className="h-9 w-full min-w-0 rounded-md bg-red-700 px-4 py-2 text-base font-medium text-white antialiased hover:bg-red-600 active:bg-red-500 lg:text-sm">
+              <a href={`/past-events/${event.slug}`} target="_blank">
+                View Detailed Stats
+              </a>
+            </Button>
+          </div>
+        )}
       </div>
-    </li>
+    </div>
   );
 }
 

--- a/app/_features/event/components/event-stat-list.tsx
+++ b/app/_features/event/components/event-stat-list.tsx
@@ -48,7 +48,16 @@ export default function PastEvents({
               <>
                 <ul className="flex flex-col gap-10">
                   {events.map((event) => {
-                    return <EventStatCard key={event.id} event={event} />;
+                    return (
+                      <li key={event.id}>
+                        <EventStatCard
+                          showEvent
+                          key={event.id}
+                          event={event}
+                          showButton
+                        />
+                      </li>
+                    );
                   })}
                 </ul>
                 {previousPage || nextPage ? (

--- a/app/_shared/components/icons/info-icon.tsx
+++ b/app/_shared/components/icons/info-icon.tsx
@@ -10,8 +10,8 @@ export default function InfoIcon(props: SVGElementPropsType) {
       fill="none"
       stroke="currentColor"
       stroke-width="2"
-      stroke-linecap="round"
-      stroke-linejoin="round"
+      strokeLinecap="round"
+      strokeLinejoin="round"
       {...props}
     >
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />

--- a/app/_shared/types/event.d.ts
+++ b/app/_shared/types/event.d.ts
@@ -17,7 +17,7 @@ export declare namespace EventType {
     data: Event;
   };
 
-  type Stat = FetcherResponse & {
+  type GetStatsResponse = FetcherResponse & {
     data: {
       count: {
         registeree: number;
@@ -71,6 +71,8 @@ export declare namespace EventType {
     data: Participant[];
     meta: PageMeta;
   };
+
+  export type EventParticipant = Participant;
 
   type Registeree = {
     id: number;


### PR DESCRIPTION
Added new page `past-events/<evenSlug>` to view past-events detail
user can view all participant and a more detailed stats

<img width="800" alt="Screenshot 2024-03-28 at 22 05 59" src="https://github.com/inlivedev/inlive-room/assets/20636513/7dc04edb-e79e-4fe7-9b3d-9fa994798036">
<img width="800" alt="image" src="https://github.com/inlivedev/inlive-room/assets/20636513/6161bdab-1c78-460f-959b-caa1614583c0">
