### PR TITLE
Fix/stats query

### DIFF
--- a/app/(server)/_features/activity-log/repository.ts
+++ b/app/(server)/_features/activity-log/repository.ts
@@ -62,14 +62,19 @@ export const countGuestParticipant = async (roomID: string) => {
   const res = await db
     .select({ value: countDistinct(sql`${activitiesLog.meta} ->> 'clientID'`) })
     .from(activitiesLog)
-    .fullJoin(
+    .leftJoin(
       participant,
       and(
         eq(sql`${activitiesLog.meta} ->> 'clientID'`, participant.clientId),
         eq(sql`${activitiesLog.meta} ->> 'roomID'`, roomID)
       )
     )
-    .where(isNull(participant.clientId));
+    .where(
+      and(
+        isNull(participant.clientId),
+        eq(sql`${activitiesLog.meta} ->> 'roomID'`, roomID)
+      )
+    );
 
   return res[0];
 };

--- a/app/(server)/_features/event/repository.ts
+++ b/app/(server)/_features/event/repository.ts
@@ -9,7 +9,7 @@ import {
   participant as participants,
   selectEvent,
 } from './schema';
-import { DBQueryConfig, SQL, and, count, eq, isNull, sql } from 'drizzle-orm';
+import { DBQueryConfig, SQL, and, count, eq, isNull,  sql } from 'drizzle-orm';
 import { PageMeta } from '@/_shared/types/types';
 import { User, users } from '../user/schema';
 import { activitiesLog } from '../activity-log/schema';
@@ -569,7 +569,7 @@ export class EventRepo implements iEventRepo {
     const participantAttendance = participants.map((participant) => {
       const parsedLogs = ArrayRoomDurationMeta.parse(participant.combined_logs)
       const totalDuration = getTotalJoinDuration(parsedLogs,event.startTime, event.endTime)/1000;
-      const isAttended = ((totalDuration / eventDuration) * 100) > percentage;
+      const isAttended = ((totalDuration / eventDuration) * 100) >= percentage;
       return {
         clientID: participant.clientID,
         joinDuration: totalDuration,

--- a/app/(server)/_features/event/repository.ts
+++ b/app/(server)/_features/event/repository.ts
@@ -497,9 +497,9 @@ export class EventRepo implements iEventRepo {
         `.as('isJoined'),
       })
       .from(subQueryUniqueConnectedClient)
-      .fullJoin(
+      .leftJoin(
         participants,
-        eq(participants.clientId, subQueryUniqueConnectedClient.clientID)
+        and(eq(participants.clientId, subQueryUniqueConnectedClient.clientID),eq(participants.eventID, eventId))
       ).as('participants')
 
     const { data, meta } = await db.transaction(async (tx) => {

--- a/app/(server)/api/events/[slugOrId]/details/participants/route.ts
+++ b/app/(server)/api/events/[slugOrId]/details/participants/route.ts
@@ -71,8 +71,10 @@ export async function GET(
       string,
       { isAttended: boolean; joinDuration: number }
     >();
-    const registeredAttendance =
-      await eventRepo.getParticipantAttendancePercentage(event.id);
+    const registeredAttendance = await eventRepo.getFullyAttendedParticipant(
+      event.id,
+      80
+    );
     registeredAttendance.participant.forEach((participant) => {
       registeredAttendanceMap.set(participant.clientID, {
         isAttended: participant.isAttended,
@@ -81,7 +83,7 @@ export async function GET(
     });
 
     res.data.forEach((participant) => {
-      participant.isAttended = registeredAttendanceMap.get(
+      participant.isFullyAttended = registeredAttendanceMap.get(
         participant.clientID
       )?.isAttended;
       participant.joinDuration = registeredAttendanceMap.get(

--- a/app/(server)/api/events/[slugOrId]/details/participants/route.ts
+++ b/app/(server)/api/events/[slugOrId]/details/participants/route.ts
@@ -83,7 +83,7 @@ export async function GET(
     });
 
     res.data.forEach((participant) => {
-      participant.isFullyAttended = registeredAttendanceMap.get(
+      participant.isAttended = registeredAttendanceMap.get(
         participant.clientID
       )?.isAttended;
       participant.joinDuration = registeredAttendanceMap.get(

--- a/app/_features/event/components/event-past-dashboard.tsx
+++ b/app/_features/event/components/event-past-dashboard.tsx
@@ -266,13 +266,13 @@ function ParticipantTable({ eventID }: { eventID: string | number }) {
                     scope="col"
                     className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
                   >
-                    Join
+                    Attend
                   </th>
                   <th
                     scope="col"
                     className="whitespace-nowrap px-3 py-2 text-xs font-medium lg:px-6 lg:py-3"
                   >
-                    Attend
+                    Fully Attended
                   </th>
                 </tr>
               </thead>
@@ -340,25 +340,19 @@ function ParticipantItem({
         {participant.email}
       </td>
       <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
-        <BooleanItem isTrue={participant.isRegistered}></BooleanItem>
+        {participant.isRegistered ? (
+          <BooleanItem isTrue={participant.isRegistered}></BooleanItem>
+        ) : (
+          <GuestIcon />
+        )}
       </td>
       <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
         <BooleanItem isTrue={participant.isJoined}></BooleanItem>
       </td>
       <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
-        {participant.isRegistered ? (
-          BooleanItem({ isTrue: participant.isAttended || false })
-        ) : (
-          <Tooltip content="Attendance for Guests Coming Soon">
-            <Button
-              isIconOnly
-              size="sm"
-              className="bg-zinc-900  ring-1 ring-zinc-800 hover:bg-zinc-900"
-            >
-              <InfoIcon className="stroke-zinc-300" />
-            </Button>
-          </Tooltip>
-        )}
+        {participant.isRegistered
+          ? BooleanItem({ isTrue: participant.isFullyAttended || false })
+          : null}
       </td>
     </tr>
   );
@@ -370,6 +364,14 @@ function BooleanItem({ isTrue }: { isTrue: boolean }) {
       <span className={isTrue ? 'text-green-800' : 'text-red-800'}>•</span>
 
       {isTrue ? 'Yes' : 'No'}
+    </div>
+  );
+}
+
+function GuestIcon() {
+  return (
+    <div className="flex h-fit w-fit gap-2 rounded-md px-2 py-1 ring-1 ring-zinc-800">
+      Guest
     </div>
   );
 }

--- a/app/_features/event/components/event-past-dashboard.tsx
+++ b/app/_features/event/components/event-past-dashboard.tsx
@@ -351,7 +351,7 @@ function ParticipantItem({
       </td>
       <td className="min-w-52 max-w-80 truncate whitespace-nowrap p-3 text-zinc-400 lg:p-6">
         {participant.isRegistered
-          ? BooleanItem({ isTrue: participant.isFullyAttended || false })
+          ? BooleanItem({ isTrue: participant.isAttended || false })
           : null}
       </td>
     </tr>

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -7,6 +7,7 @@ import { InternalApiFetcher } from '@/_shared/utils/fetcher';
 import { useFormattedDateTime } from '@/_shared/hooks/use-formatted-datetime';
 import { Button, Tooltip } from '@nextui-org/react';
 import InfoIcon from '@/_shared/components/icons/info-icon';
+import Link from 'next/link';
 
 export function EventStatCard({
   event,
@@ -112,55 +113,24 @@ export function EventStatCard({
             <>
               <StatList>
                 <StatItem
-                  name="Registered Participants"
-                  value={stat.data.count.registeree}
+                  name="Registered"
+                  value={stat.data.count.registered}
                 />
+                <StatItem name="Attended" value={stat.data.count.attended} />
                 <StatItem
-                  name="Total Participants"
-                  value={stat.data.count.totalJoined}
-                />
-                <StatItem
-                  name="Participants from Registration"
-                  value={stat.data.count.registereeJoin}
-                />
-                <StatItem
-                  name="Participants as Guest"
-                  value={stat.data.count.guestsJoin}
+                  name="Fully Attended"
+                  value={stat.data.count.fullyAttended}
                 />
 
                 <StatItem
-                  name="Registration Attendances"
-                  value={stat.data.count.registeredAttendance}
-                  message="Participant from registration that attend more than 80% of total event duration"
-                />
-
-                <StatItem
-                  name="Percentage Joined from Registration"
-                  value={`${
-                    stat.data.percentage.registeredCountRegisteree || 0
-                  } %`}
-                />
-                <StatItem
-                  name="Percentage Registered & Joined with Total Participants"
-                  value={`${stat.data.percentage.registeredCountJoin || 0} %`}
-                ></StatItem>
-                <StatItem
-                  name="Percentage Joined as Guest with Total Participant"
-                  value={`${stat.data.percentage.guestCountJoin || 0} %`}
-                />
-
-                <StatItem
-                  name="Percentage Registered & Attendded with Total Participants"
-                  value={`${
-                    stat.data.percentage.registeredAttendCountJoin || 0
-                  } %`}
+                  name="Percentage Attended"
+                  value={`${stat.data.percentage.attended || 0} %`}
                 ></StatItem>
 
                 <StatItem
-                  name="Percentage Registered Attendances"
-                  value={`${
-                    stat.data.percentage.registeredAttendCountRegisteree || 0
-                  } %`}
+                  name="Percentage Fully Attended"
+                  value={`${stat.data.percentage.fullyAttended || 0} %`}
+                  message="≥ 80% session duration"
                 ></StatItem>
               </StatList>
             </>
@@ -175,10 +145,13 @@ export function EventStatCard({
 
         {showButton && (
           <div className="start-end flex w-full border-t border-zinc-700 pb-6 pt-4">
-            <Button className="h-9 w-full min-w-0 rounded-md bg-red-700 px-4 py-2 text-base font-medium text-white antialiased hover:bg-red-600 active:bg-red-500 lg:text-sm">
-              <a href={`/past-events/${event.slug}`} target="_blank">
-                View Detailed Stats
-              </a>
+            <Button
+              as={Link}
+              href={`/past-events/${event.slug}`}
+              target="_blank"
+              className="h-9 w-full min-w-0 rounded-md bg-red-700 px-4 py-2 text-base font-medium text-white antialiased hover:bg-red-600 active:bg-red-500 lg:text-sm"
+            >
+              View Detailed Stats
             </Button>
           </div>
         )}

--- a/app/_features/event/components/event-stat-card.tsx
+++ b/app/_features/event/components/event-stat-card.tsx
@@ -119,6 +119,7 @@ export function EventStatCard({
                 <StatItem name="Attended" value={stat.data.count.attended} />
                 <StatItem
                   name="Fully Attended"
+                  message="≥ 80% session duration"
                   value={stat.data.count.fullyAttended}
                 />
 
@@ -130,7 +131,6 @@ export function EventStatCard({
                 <StatItem
                   name="Percentage Fully Attended"
                   value={`${stat.data.percentage.fullyAttended || 0} %`}
-                  message="≥ 80% session duration"
                 ></StatItem>
               </StatList>
             </>

--- a/app/_shared/types/event.d.ts
+++ b/app/_shared/types/event.d.ts
@@ -21,30 +21,18 @@ export declare namespace EventType {
   type GetStatsResponse = FetcherResponse & {
     data: {
       count: {
-        registeree: number;
-        registereeJoin: number;
-        guestsJoin: number;
-        totalJoined: number;
-        registeredAttendance: number;
+        registered: number;
+        attended: number;
+        fullyAttended: number;
 
-        // TODO
-        // guestsAttendance
-        // AllParticipantAttendance
+        // Guest is no longer able to join to event room, for old event only
+        guest?: number;
+        totalJoined?: number;
       };
 
       percentage: {
-        guestCountJoin: string; //countGuestJoin : countAllParticipantJoin
-
-        registeredCountJoin: string; //countRegisteredJoin : countAllParticipantJoin
-        registeredCountRegisteree: string; // countRegisteredJoin : countRegisteree
-
-        registeredAttendCountJoin: string; // countRegisteredAttendance : countAllParticipantJoin
-        registeredAttendCountRegisteree: string; // countRegisteredAttendance : countRegisteree
-
-        // TODO
-        // registeredAttendCountAttendance // countRegisteredAttendance : countAllParticipantAttendance
-        // guestAttendCountAttendance // countGuestAttendance : countAllParticipantAttendance
-        // guestAttendCountJoin // countGuestAttendance : countAllParticipantJoin
+        attended?: string;
+        fullyAttended?: string;
       };
     };
   };


### PR DESCRIPTION
* Fixes the Query for getting participant list on past event, previously the join was invalid resulting in showing participant from other events
  * It should only shows participant from a join table of participants with the correct eventID and activities table
  * It will also shown a guest participant from the old Implementation where user able to join event room without registering into an event
*  Updated the Stats to be shown on the past event page, now it only shows : 
   * Registered : number of registered participant into the event
   * Attended : number of registered participant that joined the event
   * Fully Attended : number of registered participant that joined the event for 80% of the event duration
   * Percentage Attended
   * Percentage Fully Attended