### PR TITLE
chore: update inlive-js-sdk to 0.19.1

### DIFF
--- a/app/(server)/_shared/utils/sdk.ts
+++ b/app/(server)/_shared/utils/sdk.ts
@@ -5,7 +5,7 @@ const inliveApiVersion = process.env.NEXT_PUBLIC_INLIVE_API_VERSION;
 const inliveHubOrigin = process.env.NEXT_PUBLIC_INLIVE_HUB_ORIGIN;
 const inliveHubVersion = process.env.NEXT_PUBLIC_INLIVE_HUB_VERSION;
 
-export const createSDKAuth = async () => {
+const createSDKAuth = async () => {
   if (typeof window !== 'undefined') return null;
 
   return createAuth({

--- a/app/(server)/_shared/utils/sdk.ts
+++ b/app/(server)/_shared/utils/sdk.ts
@@ -1,13 +1,32 @@
-import { Room } from '@inlivedev/inlive-js-sdk/dist/room';
-
+import { Room, createAuth } from '@inlivedev/inlive-js-sdk/dist/room';
+const inliveHubApiKey = process.env.INLIVE_HUB_API_KEY;
+const inliveApiOrigin = process.env.NEXT_PUBLIC_INLIVE_API_ORIGIN;
+const inliveApiVersion = process.env.NEXT_PUBLIC_INLIVE_API_VERSION;
 const inliveHubOrigin = process.env.NEXT_PUBLIC_INLIVE_HUB_ORIGIN;
 const inliveHubVersion = process.env.NEXT_PUBLIC_INLIVE_HUB_VERSION;
-const inliveHubApiKey = process.env.INLIVE_HUB_API_KEY;
 
-export const serverSDK = Room({
+export const createSDKAuth = async () => {
+  if (typeof window !== 'undefined') return null;
+
+  return createAuth({
+    apiVersion: inliveApiVersion,
+    baseUrl: inliveApiOrigin,
+    apiKey: inliveHubApiKey,
+    expirySeconds: 3600,
+  });
+};
+
+const serverSDK = Room({
   api: {
     baseUrl: inliveHubOrigin,
     version: inliveHubVersion,
-    apiKey: inliveHubApiKey,
   },
 });
+
+const sdkAuth = await createSDKAuth();
+
+if (sdkAuth) {
+  serverSDK.setAuth(sdkAuth);
+}
+
+export { serverSDK };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "room.inlive.app",
       "version": "0.1.0",
       "dependencies": {
-        "@inlivedev/inlive-js-sdk": "^0.18.0",
+        "@inlivedev/inlive-js-sdk": "^0.19.0",
         "@nextui-org/react": "^2.3.6",
         "@react-email/components": "0.0.16",
         "@sentry/nextjs": "^7.70.0",
@@ -739,9 +739,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@inlivedev/inlive-js-sdk": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.18.0.tgz",
-      "integrity": "sha512-mQItHqKfveAbhR4RvyhyiHiRXqCXD755ma0kx1XXyabuQXFZ7BuuDGGO8Gz2CbSZaGl5CDV8neLIzE91xQr5GA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.19.0.tgz",
+      "integrity": "sha512-qc79qmrpCms12ZoQLhi4LTQpERmbJgLBOL2tuXN3xv30px/WXAEJg3UktfL/pu+O67H7ErCSsn+z1EHGGFfJQQ==",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.4.0",
         "camelcase-keys": "^8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@typescript-eslint/parser": "^5.61.0",
         "autoprefixer": "^10.4.17",
         "dotenv": "^16.3.1",
-        "drizzle-kit": "^0.21.1",
+        "drizzle-kit": "^0.23.0",
         "eslint": "^8.44.0",
         "eslint-config-next": "^13.4.8",
         "eslint-config-prettier": "^8.8.0",
@@ -6606,22 +6606,6 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
-    "node_modules/cli-color": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-2.0.3.tgz",
-      "integrity": "sha512-OkoZnxyC4ERN3zLzZaY9Emb7f/MhBOIpePv0Ycok0fJYT+Ouo00UBEIwsVsr0yoow++n5YWlSUgST9GKhNHiRQ==",
-      "dev": true,
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.61",
-        "es6-iterator": "^2.0.3",
-        "memoizee": "^0.4.15",
-        "timers-ext": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
@@ -6843,16 +6827,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
-      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
-      "dev": true,
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -7058,18 +7032,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/difflib": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/difflib/-/difflib-0.2.4.tgz",
-      "integrity": "sha512-9YVwmMb0wQHQNr5J9m6BSj6fk4pfGITGQOOs+D9Fl+INODWFOfvhIU1hNv6GgR1RBoC/9NJcwu77zShxV0kT7w==",
-      "dev": true,
-      "dependencies": {
-        "heap": ">= 0.2.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -7170,33 +7132,15 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
-    "node_modules/dreamopt": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/dreamopt/-/dreamopt-0.8.0.tgz",
-      "integrity": "sha512-vyJTp8+mC+G+5dfgsY+r3ckxlz+QMX40VjPQsZc5gxVAxLmi64TBoVkP54A/pRAXMXsbu2GMMBrZPxNv23waMg==",
-      "dev": true,
-      "dependencies": {
-        "wordwrap": ">=0.0.2"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/drizzle-kit": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.21.1.tgz",
-      "integrity": "sha512-Sp7OnCdROiE2ebMuHsAfrnRoHVGYCvErQxUh7/0l6R1caHssZu9oZu/hW9rLU19xnTK4/y3iSe3sL0Cc530wCg==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.23.0.tgz",
+      "integrity": "sha512-w9jE97z193dd4jzAyj4Uv2SOh8Ydue70Ki6W0awy4bGM1aPXan6zD6Yv+nNTA6oGgNTDl2MJFxutjHG4fden5g==",
       "dev": true,
       "dependencies": {
         "@esbuild-kit/esm-loader": "^2.5.5",
-        "commander": "^9.4.1",
-        "env-paths": "^3.0.0",
         "esbuild": "^0.19.7",
-        "esbuild-register": "^3.5.0",
-        "glob": "^8.1.0",
-        "hanji": "^0.0.5",
-        "json-diff": "0.9.0",
-        "zod": "^3.20.2"
+        "esbuild-register": "^3.5.0"
       },
       "bin": {
         "drizzle-kit": "bin.cjs"
@@ -7554,24 +7498,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/drizzle-kit/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/commander": {
-      "version": "9.5.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || >=14"
-      }
-    },
     "node_modules/drizzle-kit/node_modules/esbuild": {
       "version": "0.19.11",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.19.11.tgz",
@@ -7608,37 +7534,6 @@
         "@esbuild/win32-arm64": "0.19.11",
         "@esbuild/win32-ia32": "0.19.11",
         "@esbuild/win32-x64": "0.19.11"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/drizzle-kit/node_modules/glob/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/drizzle-orm": {
@@ -7912,18 +7807,6 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/env-paths": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/es-abstract": {
       "version": "1.21.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.2.tgz",
@@ -8034,54 +7917,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.62.tgz",
-      "integrity": "sha512-BHLqn0klhEpnOKSrzn/Xsz2UIW8j+cGmo9JLzr8BiUapV8hPL9+FliFqjwr9ngW7jWdnxv6eO+/LqyhJVqgrjA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
-      "dev": true,
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
-      "dev": true,
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
-    },
-    "node_modules/es6-weak-map": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
-      "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
-      "dev": true,
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.46",
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.1"
       }
     },
     "node_modules/esbuild": {
@@ -8690,16 +8525,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
-      "dev": true,
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
-      }
-    },
     "node_modules/events": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
@@ -8784,21 +8609,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
-      "dev": true,
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.2.tgz",
-      "integrity": "sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==",
-      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -9289,16 +9099,6 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="
     },
-    "node_modules/hanji": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/hanji/-/hanji-0.0.5.tgz",
-      "integrity": "sha512-Abxw1Lq+TnYiL4BueXqMau222fPSPMFtya8HdpWsz/xVAhifXou71mPh/kY2+08RgFcVccjG3uZHs6K5HAe3zw==",
-      "dev": true,
-      "dependencies": {
-        "lodash.throttle": "^4.1.1",
-        "sisteransi": "^1.0.5"
-      }
-    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -9386,12 +9186,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/heap": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/heap/-/heap-0.2.7.tgz",
-      "integrity": "sha512-2bsegYkkHO+h/9MGbn6KWcE45cHZgPANo5LXF7EvWdT0yT2EguSVO1nDgU5c8+ZOPwp2vMNa7YFsJhVcDR9Sdg==",
-      "dev": true
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -9872,12 +9666,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-promise": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
-      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
-      "dev": true
-    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -10169,23 +9957,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/json-diff": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/json-diff/-/json-diff-0.9.0.tgz",
-      "integrity": "sha512-cVnggDrVkAAA3OvFfHpFEhOnmcsUpleEKq4d4O8sQWWSH40MBrWstKigVB1kGrgLWzuom+7rRdaCsnBD6VyObQ==",
-      "dev": true,
-      "dependencies": {
-        "cli-color": "^2.0.0",
-        "difflib": "~0.2.1",
-        "dreamopt": "~0.8.0"
-      },
-      "bin": {
-        "json-diff": "bin/json-diff.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -10417,12 +10188,6 @@
       "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
       "integrity": "sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg=="
     },
-    "node_modules/lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
-      "dev": true
-    },
     "node_modules/log-symbols": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
@@ -10466,15 +10231,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/lru-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
-      "dev": true,
-      "dependencies": {
-        "es5-ext": "~0.10.2"
       }
     },
     "node_modules/magic-string": {
@@ -10543,22 +10299,6 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/memoizee": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.15.tgz",
-      "integrity": "sha512-UBWmJpLZd5STPm7PMUlOw/TSy972M+z8gcyQ5veOnSDRREz/0bmpyTfKt3/51DhEBqCZQn1udM/5flcSPYhkdQ==",
-      "dev": true,
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.53",
-        "es6-weak-map": "^2.0.3",
-        "event-emitter": "^0.3.5",
-        "is-promise": "^2.2.2",
-        "lru-queue": "^0.1.0",
-        "next-tick": "^1.1.0",
-        "timers-ext": "^0.1.7"
       }
     },
     "node_modules/merge-descriptors": {
@@ -10784,12 +10524,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "dev": true
     },
     "node_modules/next/node_modules/nanoid": {
       "version": "3.3.7",
@@ -13374,12 +13108,6 @@
         "is-arrayish": "^0.3.1"
       }
     },
-    "node_modules/sisteransi": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
-      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
-      "dev": true
-    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -13996,16 +13724,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha512-b85NUNzTSdodShTIbky6ZF02e8STtVVfD+fu4aXXShEELpozH+bCpJLYMPZbsABN2wDH7fJpqIoXxJpzbf0NqQ==",
-      "dev": true,
-      "dependencies": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
-      }
-    },
     "node_modules/titleize": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
@@ -14567,12 +14285,6 @@
         "@esbuild/win32-x64": "0.19.12"
       }
     },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/type/-/type-1.2.0.tgz",
-      "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
-      "dev": true
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -14995,12 +14707,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
-      "dev": true
     },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "room.inlive.app",
       "version": "0.1.0",
       "dependencies": {
-        "@inlivedev/inlive-js-sdk": "^0.19.0",
+        "@inlivedev/inlive-js-sdk": "^0.19.1",
         "@nextui-org/react": "^2.3.6",
         "@react-email/components": "0.0.16",
         "@sentry/nextjs": "^7.70.0",
@@ -739,9 +739,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@inlivedev/inlive-js-sdk": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.19.0.tgz",
-      "integrity": "sha512-qc79qmrpCms12ZoQLhi4LTQpERmbJgLBOL2tuXN3xv30px/WXAEJg3UktfL/pu+O67H7ErCSsn+z1EHGGFfJQQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@inlivedev/inlive-js-sdk/-/inlive-js-sdk-0.19.1.tgz",
+      "integrity": "sha512-B7cZsXPURvn9rAgl9V4licncYsZ7XYSKsFwmbi38PqM9CA5C1dliuDZAO1ep3tQAQ7KbGsFD/vRIMvXMQNGFgQ==",
       "dependencies": {
         "@fingerprintjs/fingerprintjs": "^3.4.0",
         "camelcase-keys": "^8.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:studio": "npx drizzle-kit studio"
   },
   "dependencies": {
-    "@inlivedev/inlive-js-sdk": "^0.19.0",
+    "@inlivedev/inlive-js-sdk": "^0.19.1",
     "@nextui-org/react": "^2.3.6",
     "@react-email/components": "0.0.16",
     "@sentry/nextjs": "^7.70.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "db:studio": "npx drizzle-kit studio"
   },
   "dependencies": {
-    "@inlivedev/inlive-js-sdk": "^0.18.0",
+    "@inlivedev/inlive-js-sdk": "^0.19.0",
     "@nextui-org/react": "^2.3.6",
     "@react-email/components": "0.0.16",
     "@sentry/nextjs": "^7.70.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@typescript-eslint/parser": "^5.61.0",
     "autoprefixer": "^10.4.17",
     "dotenv": "^16.3.1",
-    "drizzle-kit": "^0.21.1",
+    "drizzle-kit": "^0.23.0",
     "eslint": "^8.44.0",
     "eslint-config-next": "^13.4.8",
     "eslint-config-prettier": "^8.8.0",


### PR DESCRIPTION
## Changelogs
- Accomodate SDK change based on [this PR](https://github.com/inlivedev/inlive-js-sdk/pull/113) and following the newer initialization with create auth module. This change only happens on server side SDK because the client side one still doesn't need auth mechanism.
- Updated drizzle kit to 0.23.0 because 0.21.1 complained and asked for update.