### PR TITLE
fix: switching mic and camera devices on mute turning on the video and audio to other users

### DIFF
--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect, useCallback } from 'react';
 import {
   Dropdown,
   DropdownTrigger,
@@ -11,7 +10,6 @@ import {
   Button,
 } from '@nextui-org/react';
 import type { Selection } from '@nextui-org/react';
-import { useToggle } from '@/_shared/hooks/use-toggle';
 import { useDeviceContext } from '@/_features/room/contexts/device-context';
 import CameraOnIcon from '@/_shared/components/icons/camera-on-icon';
 import CameraOffIcon from '@/_shared/components/icons/camera-off-icon';
@@ -19,8 +17,13 @@ import { useSelectDevice } from '@/_features/room/hooks/use-select-device';
 import ArrowDownFillIcon from '@/_shared/components/icons/arrow-down-fill-icon';
 
 export default function ButtonCamera() {
-  const { active, setActive, setInActive } = useToggle(true);
-  const { currentVideoInput, videoInputs, devices } = useDeviceContext();
+  const {
+    currentVideoInput,
+    videoInputs,
+    devices,
+    activeCamera,
+    setActiveCamera,
+  } = useDeviceContext();
 
   const {
     selectedDeviceKey: selectedVideoInputKey,
@@ -33,42 +36,31 @@ export default function ButtonCamera() {
       ? ['camera-default']
       : selectedVideoInputKey;
 
-  const onDeviceSelectionChange = useCallback(
-    (selectedKey: Selection) => {
-      if (!(selectedKey instanceof Set) || selectedKey.size === 0) return;
+  const onDeviceSelectionChange = (selectedKey: Selection) => {
+    if (!(selectedKey instanceof Set) || selectedKey.size === 0) return;
 
-      const currentSelected = devices.find((device) => {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        //@ts-ignore
-        return `${device.kind}-${device.deviceId}` === selectedKey.currentKey;
-      });
+    const currentSelected = devices.find((device) => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      return `${device.kind}-${device.deviceId}` === selectedKey.currentKey;
+    });
 
-      if (currentSelected?.kind === 'videoinput') {
-        onVideoInputSelectionChange(selectedKey, currentSelected);
-      }
-    },
-    [devices, onVideoInputSelectionChange]
-  );
-
-  const handleClick = useCallback(() => {
-    if (active) {
-      document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
-    } else {
-      document.dispatchEvent(new CustomEvent('trigger:turnon-camera'));
+    if (currentSelected?.kind === 'videoinput') {
+      onVideoInputSelectionChange(selectedKey, currentSelected);
     }
-  }, [active]);
+  };
 
-  useEffect(() => {
-    const onTurnOnCamera = () => setActive();
-    const onTurnOffCamera = () => setInActive();
-    document.addEventListener('trigger:turnon-camera', onTurnOnCamera);
-    document.addEventListener('trigger:turnoff-camera', onTurnOffCamera);
+  const handleClick = () => {
+    if (activeCamera) {
+      setActiveCamera(false);
+      document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
+      return;
+    }
 
-    return () => {
-      document.removeEventListener('trigger:turnon-camera', onTurnOnCamera);
-      document.removeEventListener('trigger:turnoff-camera', onTurnOffCamera);
-    };
-  }, [setActive, setInActive]);
+    setActiveCamera(true);
+    document.dispatchEvent(new CustomEvent('trigger:turnon-camera'));
+    return;
+  };
 
   return (
     <ButtonGroup variant="flat">
@@ -79,7 +71,7 @@ export default function ButtonCamera() {
         className="w-12 bg-zinc-700/70 hover:bg-zinc-600 active:bg-zinc-500"
         onClick={handleClick}
       >
-        {active ? (
+        {activeCamera ? (
           <CameraOnIcon width={20} height={20} />
         ) : (
           <CameraOffIcon width={20} height={20} className="text-red-500" />

--- a/app/_features/room/components/button-camera.tsx
+++ b/app/_features/room/components/button-camera.tsx
@@ -53,12 +53,10 @@ export default function ButtonCamera() {
   const handleClick = () => {
     if (activeCamera) {
       setActiveCamera(false);
-      document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
       return;
     }
 
     setActiveCamera(true);
-    document.dispatchEvent(new CustomEvent('trigger:turnon-camera'));
     return;
   };
 

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -17,26 +17,6 @@ export default function EventContainer({
   const { peer, debug } = usePeerContext();
 
   useEffect(() => {
-    if (!peer) return;
-
-    const onTurnOnMic = () => {
-      if (peer) peer.turnOnMic();
-    };
-
-    const onTurnOffMic = () => {
-      if (peer) peer.turnOffMic();
-    };
-
-    document.addEventListener('trigger:turnon-mic', onTurnOnMic);
-    document.addEventListener('trigger:turnoff-mic', onTurnOffMic);
-
-    return () => {
-      document.removeEventListener('trigger:turnon-mic', onTurnOnMic);
-      document.removeEventListener('trigger:turnoff-mic', onTurnOffMic);
-    };
-  }, [peer]);
-
-  useEffect(() => {
     const peerConnection = peer?.getPeerConnection();
 
     if (!peer || !peerConnection) return;

--- a/app/_features/room/components/event-container.tsx
+++ b/app/_features/room/components/event-container.tsx
@@ -1,7 +1,6 @@
 'use client';
 import { useEffect } from 'react';
 import { usePeerContext } from '@/_features/room/contexts/peer-context';
-import { hasTouchScreen } from '@/_shared/utils/has-touch-screen';
 
 declare global {
   interface Window {
@@ -20,14 +19,6 @@ export default function EventContainer({
   useEffect(() => {
     if (!peer) return;
 
-    const onTurnOnCamera = () => {
-      if (peer) peer.turnOnCamera();
-    };
-
-    const onTurnOffCamera = () => {
-      if (peer) peer.turnOffCamera();
-    };
-
     const onTurnOnMic = () => {
       if (peer) peer.turnOnMic();
     };
@@ -36,35 +27,12 @@ export default function EventContainer({
       if (peer) peer.turnOffMic();
     };
 
-    document.addEventListener('trigger:turnon-camera', onTurnOnCamera);
-    document.addEventListener('trigger:turnoff-camera', onTurnOffCamera);
     document.addEventListener('trigger:turnon-mic', onTurnOnMic);
     document.addEventListener('trigger:turnoff-mic', onTurnOffMic);
 
     return () => {
-      document.removeEventListener('trigger:turnon-camera', onTurnOnCamera);
-      document.removeEventListener('trigger:turnoff-camera', onTurnOffCamera);
       document.removeEventListener('trigger:turnon-mic', onTurnOnMic);
       document.removeEventListener('trigger:turnoff-mic', onTurnOffMic);
-    };
-  }, [peer]);
-
-  useEffect(() => {
-    if (!peer) return;
-
-    const isTouchScreen = hasTouchScreen();
-
-    const onWindowBlur = () => {
-      if (isTouchScreen && peer) {
-        document.dispatchEvent(new CustomEvent('trigger:turnoff-camera'));
-        document.dispatchEvent(new CustomEvent('trigger:turnoff-mic'));
-      }
-    };
-
-    window.addEventListener('blur', onWindowBlur);
-
-    return () => {
-      window.removeEventListener('blur', onWindowBlur);
     };
   }, [peer]);
 

--- a/app/_features/room/contexts/device-context.tsx
+++ b/app/_features/room/contexts/device-context.tsx
@@ -4,6 +4,7 @@ import {
   useEffect,
   useState,
   useCallback,
+  useRef,
 } from 'react';
 import { clientSDK, RoomEvent } from '@/_shared/utils/sdk';
 import { usePeerContext } from '@/_features/room/contexts/peer-context';
@@ -50,6 +51,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   });
 
   const { peer } = usePeerContext();
+  const didMount = useRef(false);
 
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
 
@@ -182,7 +184,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   );
 
   useEffect(() => {
-    if (peer) {
+    if (peer && didMount.current) {
       if (devicesState.activeCamera) {
         peer.turnOnCamera();
         return;
@@ -194,7 +196,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   }, [peer, devicesState.activeCamera]);
 
   useEffect(() => {
-    if (peer) {
+    if (peer && didMount.current) {
       if (devicesState.activeMic) {
         peer.turnOnMic();
         return;
@@ -207,6 +209,8 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     if (!peer) return;
+    if (!didMount.current) didMount.current = true;
+
     const isTouchScreen = hasTouchScreen();
     const onWindowBlur = () => {
       if (isTouchScreen && peer) {

--- a/app/_features/room/contexts/device-context.tsx
+++ b/app/_features/room/contexts/device-context.tsx
@@ -7,28 +7,25 @@ import {
 } from 'react';
 import { clientSDK, RoomEvent } from '@/_shared/utils/sdk';
 
-const defaultValue = {
-  currentAudioInput: undefined as MediaDeviceInfo | undefined,
-  currentAudioOutput: undefined as MediaDeviceInfo | undefined,
-  currentVideoInput: undefined as MediaDeviceInfo | undefined,
-  audioInputs: [] as MediaDeviceInfo[],
-  audioOutputs: [] as MediaDeviceInfo[],
-  videoInputs: [] as MediaDeviceInfo[],
-  devices: [] as MediaDeviceInfo[],
-  activeMic: false,
-  activeCamera: true,
+type DeviceContextStateType = {
+  currentAudioInput: MediaDeviceInfo | undefined;
+  currentAudioOutput: MediaDeviceInfo | undefined;
+  currentVideoInput: MediaDeviceInfo | undefined;
+  audioInputs: MediaDeviceInfo[];
+  audioOutputs: MediaDeviceInfo[];
+  videoInputs: MediaDeviceInfo[];
+  devices: MediaDeviceInfo[];
+  activeMic: boolean;
+  activeCamera: boolean;
 };
 
-type SetCurrentDeviceType = (deviceInfo: MediaDeviceInfo) => void;
-type SetActiveMicType = (active?: boolean) => void;
-type SetActiveCameraType = (active?: boolean) => void;
+type DeviceContextType = DeviceContextStateType & {
+  setCurrentDevice: (deviceInfo: MediaDeviceInfo) => void;
+  setActiveMic: (active?: boolean) => void;
+  setActiveCamera: (active?: boolean) => void;
+};
 
-const DeviceContext = createContext({
-  ...defaultValue,
-  setCurrentDevice: undefined as SetCurrentDeviceType | undefined,
-  setActiveMic: undefined as SetActiveMicType | undefined,
-  setActiveCamera: undefined as SetActiveCameraType | undefined,
-});
+const DeviceContext = createContext(undefined as unknown as DeviceContextType);
 
 export const AudioOutputContext =
   typeof window !== 'undefined' ? new AudioContext() : null;
@@ -38,10 +35,21 @@ export const useDeviceContext = () => {
 };
 
 export function DeviceProvider({ children }: { children: React.ReactNode }) {
-  const [devicesState, setDevicesState] = useState(defaultValue);
+  const [devicesState, setDevicesState] = useState<DeviceContextStateType>({
+    currentAudioInput: undefined,
+    currentAudioOutput: undefined,
+    currentVideoInput: undefined,
+    audioInputs: [],
+    audioOutputs: [],
+    videoInputs: [],
+    devices: [],
+    activeMic: false,
+    activeCamera: true,
+  });
+
   const [localStream, setLocalStream] = useState<MediaStream | null>(null);
 
-  const setCurrentDevice = useCallback((deviceInfo: MediaDeviceInfo) => {
+  const setCurrentDevice = (deviceInfo: MediaDeviceInfo) => {
     setDevicesState((prevState) => {
       const newData = { ...prevState };
 
@@ -55,7 +63,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
 
       return { ...newData };
     });
-  }, []);
+  };
 
   const setActiveCamera = (active = true) => {
     setDevicesState((prevState) => ({ ...prevState, activeCamera: active }));

--- a/app/_features/room/contexts/device-context.tsx
+++ b/app/_features/room/contexts/device-context.tsx
@@ -207,11 +207,9 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
   }, [peer, localStream, devicesState.activeMic]);
 
   useEffect(() => {
-    if (!peer) return;
-
     const isTouchScreen = hasTouchScreen();
     const onWindowBlur = () => {
-      if (isTouchScreen && peer) {
+      if (isTouchScreen && peer && localStream) {
         setActiveCamera(false);
         setActiveMic(false);
       }
@@ -221,7 +219,7 @@ export function DeviceProvider({ children }: { children: React.ReactNode }) {
     return () => {
       window.removeEventListener('blur', onWindowBlur);
     };
-  }, [peer]);
+  }, [peer, localStream]);
 
   useEffect(() => {
     const onMediaInputTurnedOn = ((event: CustomEvent) => {

--- a/app/_features/room/hooks/use-select-device.ts
+++ b/app/_features/room/hooks/use-select-device.ts
@@ -14,7 +14,7 @@ export const useSelectDevice = (
 ) => {
   const { peer } = usePeerContext();
   const { streams } = useParticipantContext();
-  const { setCurrentDevice } = useDeviceContext();
+  const { setCurrentDevice, activeCamera, activeMic } = useDeviceContext();
 
   const [selectedDeviceKeyState, setSelectedDeviceKeyState] = useState<
     Set<Key>
@@ -66,9 +66,10 @@ export const useSelectDevice = (
             const track = mediaStream.getAudioTracks()[0];
             await peer.replaceTrack(track);
             localStream.replaceTrack(track);
+            if (!activeMic) peer.turnOffMic();
 
             setSelectedDeviceKeyState(selectedDeviceKeys);
-            setCurrentDevice && setCurrentDevice(currentSelectedDevice);
+            setCurrentDevice(currentSelectedDevice);
           }
         } else if (currentSelectedDevice.kind === 'audiooutput') {
           if (
@@ -86,8 +87,8 @@ export const useSelectDevice = (
           }
 
           setSelectedDeviceKeyState(selectedDeviceKeys);
-          setCurrentDevice && setCurrentDevice(currentSelectedDevice);
-        } else {
+          setCurrentDevice(currentSelectedDevice);
+        } else if (currentSelectedDevice.kind === 'videoinput') {
           for (const videoTrack of localStream.mediaStream.getVideoTracks()) {
             videoTrack.stop();
           }
@@ -100,16 +101,17 @@ export const useSelectDevice = (
             const track = mediaStream.getVideoTracks()[0];
             await peer.replaceTrack(track);
             localStream.replaceTrack(track);
+            if (!activeCamera) peer.turnOffCamera();
 
             setSelectedDeviceKeyState(selectedDeviceKeys);
-            setCurrentDevice && setCurrentDevice(currentSelectedDevice);
+            setCurrentDevice(currentSelectedDevice);
           }
         }
       } catch (error) {
         console.error(error);
       }
     },
-    [peer, streams, setCurrentDevice]
+    [peer, streams, setCurrentDevice, activeCamera, activeMic]
   );
 
   const selectDeviceOptions = useMemo(() => {


### PR DESCRIPTION
## Changelogs
- Fix issue about switching mic and camera devices on mute turning on the video and audio to other users. Now, switching mic and camera still retains the mute state and when the unmute button is clicked, user will use the new device.
- Refactor the logic to use context state for listening on/off camera and mic instead of using custom event.