### PR TITLE
refactor: make webinar room experience same with meeting room

### DIFF
--- a/app/_features/room/components/conference-top-bar.tsx
+++ b/app/_features/room/components/conference-top-bar.tsx
@@ -53,117 +53,8 @@ export default function ConferenceTopBar({ sidebar }: { sidebar: Sidebar }) {
           <PeopleIcon className="h-5 w-5" />
           <span>{participants.length}</span>
         </Button>
-        {roomType === 'event' && isModerator && <DropdownViewSelection />}
       </div>
     </div>
-  );
-}
-
-function DropdownViewSelection() {
-  const { previousLayout, currentLayout } = useMetadataContext();
-  const { roomID } = useClientContext();
-
-  const onViewSelectionChange = useCallback(
-    async (selectedKey: Selection) => {
-      if (!(selectedKey instanceof Set) || selectedKey.size === 0) return;
-
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      //@ts-ignore
-      const currentKey: 'gallery' | 'speaker' = selectedKey.currentKey;
-
-      await clientSDK.setMetadata(roomID, {
-        currentLayout: currentKey,
-        previousLayout: currentLayout,
-      });
-    },
-    [roomID, currentLayout]
-  );
-
-  const selectedKeys =
-    currentLayout !== 'presentation'
-      ? new Set([currentLayout])
-      : new Set([previousLayout]);
-
-  return (
-    <Dropdown className="min-w-40 ring-1 ring-zinc-800/70">
-      <DropdownTrigger>
-        <Button
-          className={`h-auto min-h-0 min-w-0 gap-0 rounded-xl bg-zinc-700/70 px-2 py-1.5 text-xs font-medium antialiased hover:bg-zinc-600 active:bg-zinc-500 ${
-            currentLayout === 'presentation'
-              ? 'cursor-not-allowed'
-              : 'cursor-auto'
-          }`}
-          isDisabled={currentLayout === 'presentation'}
-          aria-disabled={currentLayout === 'presentation'}
-          disabled={currentLayout === 'presentation'}
-        >
-          <span>
-            <GridViewIcon className="h-5 w-5" />
-          </span>
-          <span className="ml-2 capitalize">
-            {currentLayout !== 'presentation' ? currentLayout : previousLayout}{' '}
-            View
-          </span>
-          <span className="ml-2">
-            <ChevronDownIcon className="h-3 w-3" />
-          </span>
-        </Button>
-      </DropdownTrigger>
-      <DropdownMenu
-        disallowEmptySelection
-        aria-label="Choose a view"
-        selectionMode="single"
-        selectedKeys={selectedKeys}
-        onSelectionChange={onViewSelectionChange}
-      >
-        <DropdownItem
-          key="speaker"
-          className="py-1 text-zinc-400 hover:text-zinc-200"
-          textValue="Speaker View"
-        >
-          <div className="flex items-center gap-1.5 text-xs font-medium">
-            <span>
-              <ThreeGridIcon className="h-6 w-6" />
-            </span>
-            <span>Speaker View</span>
-          </div>
-        </DropdownItem>
-        <DropdownItem
-          key="gallery"
-          className="py-1 text-zinc-400 hover:text-zinc-200"
-          textValue="Gallery View"
-        >
-          <div className="flex items-center gap-1.5 text-xs font-medium">
-            <span>
-              <FourGridIcon className="h-6 w-6" />
-            </span>
-            <span>Gallery View</span>
-          </div>
-        </DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
-  );
-}
-
-function GridViewIcon(props: SVGElementPropsType) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
-      <path
-        fill="currentColor"
-        d="M6.25 12.5c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4Zm7.5 0c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4ZM6.25 7C5.56 7 5 7.56 5 8.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2c0-.69-.56-1.25-1.25-1.25h-4Zm7.5 0c-.69 0-1.25.56-1.25 1.25v2c0 .69.56 1.25 1.25 1.25h4c.69 0 1.25-.56 1.25-1.25v-2C19 7.56 18.44 7 17.75 7h-4ZM2 6.75A2.75 2.75 0 0 1 4.75 4h14.5A2.75 2.75 0 0 1 22 6.75v10.5A2.75 2.75 0 0 1 19.25 20H4.75A2.75 2.75 0 0 1 2 17.25V6.75ZM4.75 5.5c-.69 0-1.25.56-1.25 1.25v10.5c0 .69.56 1.25 1.25 1.25h14.5c.69 0 1.25-.56 1.25-1.25V6.75c0-.69-.56-1.25-1.25-1.25H4.75Z"
-      />
-    </svg>
-  );
-}
-
-function ChevronDownIcon(props: SVGElementPropsType) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 12" {...props}>
-      <path
-        fill="currentColor"
-        d="M2.22 4.47a.75.75 0 0 1 1.06 0L6 7.19l2.72-2.72a.75.75 0 0 1 1.06 1.06L6.53 8.78a.75.75 0 0 1-1.06 0L2.22 5.53a.75.75 0 0 1 0-1.06Z"
-      />
-    </svg>
   );
 }
 
@@ -173,28 +64,6 @@ function PeopleIcon(props: SVGElementPropsType) {
       <path
         fill="currentColor"
         d="M16 17v2H2v-2s0-4 7-4s7 4 7 4m-3.5-9.5A3.5 3.5 0 1 0 9 11a3.5 3.5 0 0 0 3.5-3.5m3.44 5.5A5.32 5.32 0 0 1 18 17v2h4v-2s0-3.63-6.06-4M15 4a3.39 3.39 0 0 0-1.93.59a5 5 0 0 1 0 5.82A3.39 3.39 0 0 0 15 11a3.5 3.5 0 0 0 0-7Z"
-      />
-    </svg>
-  );
-}
-
-function ThreeGridIcon(props: SVGElementPropsType) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" {...props}>
-      <path
-        fill="currentColor"
-        d="M6 3a3 3 0 0 0-3 3v3.5h14V6a3 3 0 0 0-3-3zm11 7.5h-6.5V17H14a3 3 0 0 0 3-3zm-7.5 0H3V14a3 3 0 0 0 3 3h3.5z"
-      />
-    </svg>
-  );
-}
-
-function FourGridIcon(props: SVGElementPropsType) {
-  return (
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" {...props}>
-      <path
-        fill="currentColor"
-        d="M17.75 21h-5v-8.25H21v5A3.25 3.25 0 0 1 17.75 21M21 11.25h-8.25V3h5A3.25 3.25 0 0 1 21 6.25zm-9.75 0V3h-5A3.25 3.25 0 0 0 3 6.25v5zM3 12.75v5A3.25 3.25 0 0 0 6.25 21h5v-8.25z"
       />
     </svg>
   );

--- a/app/_features/room/components/participant-dropdown-menu.tsx
+++ b/app/_features/room/components/participant-dropdown-menu.tsx
@@ -176,24 +176,6 @@ export default function ParticipantDropdownMenu({
               ]
             : undefined,
           // @ts-ignore
-          isModerator &&
-          clientID !== stream.clientId &&
-          stream.source === 'media' &&
-          roomType === 'event' &&
-          currentLayout === 'speaker'
-            ? [
-                speakerClientIDs.includes(stream.clientId) ? (
-                  <DropdownItem key="set-regular-participant">
-                    Set as a regular participant
-                  </DropdownItem>
-                ) : (
-                  <DropdownItem key="set-speaker">
-                    Set as a speaker
-                  </DropdownItem>
-                ),
-              ]
-            : undefined,
-          // @ts-ignore
           isModerator && stream.origin === 'remote' && stream.source === 'media'
             ? [
                 <DropdownItem key="remove-client">

--- a/app/_features/room/components/participant-dropdown-menu.tsx
+++ b/app/_features/room/components/participant-dropdown-menu.tsx
@@ -22,9 +22,8 @@ export default function ParticipantDropdownMenu({
   stream: ParticipantVideo;
   children: React.ReactNode;
 }) {
-  const { roomID, clientID } = useClientContext();
-  const { speakerClientIDs, spotlights, isModerator, roomType, currentLayout } =
-    useMetadataContext();
+  const { roomID } = useClientContext();
+  const { speakerClientIDs, spotlights, isModerator } = useMetadataContext();
   const { datachannels } = useDataChannelContext();
 
   const onMoreSelection = useCallback(
@@ -70,40 +69,6 @@ export default function ParticipantDropdownMenu({
             },
           })
         );
-      } else if (key === 'set-speaker') {
-        if (!isModerator) return;
-
-        try {
-          await clientSDK.setMetadata(roomID, {
-            speakerClientIDs: [...speakerClientIDs, stream.clientId],
-          });
-        } catch (error) {
-          Sentry.captureException(error, {
-            extra: {
-              message: `API call error when trying to set metadata speakerClientIDs`,
-            },
-          });
-          console.error(error);
-        }
-      } else if (key === 'set-regular-participant') {
-        if (!isModerator) return;
-
-        try {
-          const newSpeakerClientIDs = speakerClientIDs.filter((speaker) => {
-            return speaker !== stream.clientId;
-          });
-
-          await clientSDK.setMetadata(roomID, {
-            speakerClientIDs: newSpeakerClientIDs,
-          });
-        } catch (error) {
-          Sentry.captureException(error, {
-            extra: {
-              message: `API call error when trying to set metadata speakerClientIDs`,
-            },
-          });
-          console.error(error);
-        }
       } else if (key === 'remove-client') {
         if (!isModerator) return;
 
@@ -125,7 +90,7 @@ export default function ParticipantDropdownMenu({
         }
       }
     },
-    [roomID, speakerClientIDs, stream, isModerator, spotlights, datachannels]
+    [roomID, stream, isModerator, spotlights, datachannels]
   );
 
   return (

--- a/app/_features/room/components/participant-dropdown-menu.tsx
+++ b/app/_features/room/components/participant-dropdown-menu.tsx
@@ -23,7 +23,7 @@ export default function ParticipantDropdownMenu({
   children: React.ReactNode;
 }) {
   const { roomID } = useClientContext();
-  const { speakerClientIDs, spotlights, isModerator } = useMetadataContext();
+  const { spotlights, isModerator } = useMetadataContext();
   const { datachannels } = useDataChannelContext();
 
   const onMoreSelection = useCallback(

--- a/app/_features/room/contexts/metadata-context.tsx
+++ b/app/_features/room/contexts/metadata-context.tsx
@@ -33,7 +33,7 @@ export function MetadataProvider({
   roomType: string;
   isModerator: boolean;
 }) {
-  const defaultLayout = roomType === 'event' ? 'speaker' : 'gallery';
+  const defaultLayout = 'gallery';
 
   const [metadataState, setMetadataState] = useState<typeof defaultData>({
     ...defaultData,

--- a/app/_features/room/contexts/metadata-context.tsx
+++ b/app/_features/room/contexts/metadata-context.tsx
@@ -10,8 +10,8 @@ const defaultData = {
   isModerator: false as boolean,
   moderatorClientIDs: [] as string[],
   roomType: 'meeting' as string,
-  previousLayout: 'gallery' as 'gallery' | 'speaker' | 'presentation',
-  currentLayout: 'gallery' as 'gallery' | 'speaker' | 'presentation',
+  previousLayout: 'gallery' as 'gallery' | 'presentation',
+  currentLayout: 'gallery' as 'gallery' | 'presentation',
   speakerClientIDs: [] as string[],
   spotlights: [] as string[],
 };


### PR DESCRIPTION
We have decided that the webinar and meeting experiences should be the same. For now, we plan to make the layout between the webinar and meeting rooms are similar.

## Changelogs
- Default layout for webinar room is gallery layout.
- Remove dropdown view selection which changes to gallery or stage layouts. In the future, stage layout should be based on multiple spotlights.
- Remove set speaker and set regular participant dropdown options.