### PR TITLE
feat: rewrite middleware for scheduled-meeting allow no clientID

### DIFF
--- a/app/(server)/_features/event/repository.ts
+++ b/app/(server)/_features/event/repository.ts
@@ -467,7 +467,7 @@ export class EventRepo {
     return res;
   }
 
-  async getRoomWithEvent(roomID: string, _db: DB = db): Promise<
+  async getEventWithRoom(roomID: string, _db: DB = db): Promise<
     selectEvent & {
       room: selectRoom
       category: {

--- a/app/(server)/_features/event/service.ts
+++ b/app/(server)/_features/event/service.ts
@@ -2,6 +2,7 @@ import { eventRepo } from '@/(server)/api/_index';
 import {
   insertEvent,
   insertParticipant,
+  selectCategory,
   selectEvent,
   selectRole,
 } from './schema';
@@ -47,6 +48,7 @@ export interface EventParticipant {
 export interface EventDetails extends selectEvent {
   host?: selectUser;
   availableSlots?: number;
+  category?: selectCategory;
 }
 
 export class EventService {

--- a/app/(server)/_features/room/service.ts
+++ b/app/(server)/_features/room/service.ts
@@ -4,13 +4,15 @@ import { getServerSDK } from '@/(server)/_shared/utils/sdk';
 import { insertRoom, selectRoom } from './schema';
 import { eventRepo } from '@/(server)/api/_index';
 import { ServiceError } from '../_service';
+import { selectCategory, selectEvent } from '../event/schema';
 
-export interface Room {
-  id: string;
-  name?: string | null;
-  createdBy: number;
-  meta: { [key: string]: any };
-}
+export type Room = selectRoom & {
+  event?:
+    | (selectEvent & {
+        category?: selectCategory;
+      })
+    | null;
+};
 
 export interface Client {
   clientID: string;

--- a/app/(server)/_features/room/service.ts
+++ b/app/(server)/_features/room/service.ts
@@ -99,8 +99,6 @@ export class RoomService {
     const event = await eventRepo.getEventWithRoom(roomId);
 
     if (event) {
-      console.log(JSON.stringify(event));
-
       if (event.category?.name != 'meetings') {
         if (!clientID) throw new Error('Client ID is required for event room');
 
@@ -212,7 +210,6 @@ export class RoomService {
       if (roomResp.code > 299) {
         console.error(roomResp.message);
         Sentry.captureMessage(`Failed to create a room ${roomID}.`, 'error');
-        console.log(JSON.stringify(roomResp));
         throw new Error(
           'Error during creating room, please try again later ' +
             roomResp.message

--- a/app/(server)/_features/room/service.ts
+++ b/app/(server)/_features/room/service.ts
@@ -96,7 +96,7 @@ export class RoomService {
       throw new Error('Room not found');
     }
 
-    const event = await eventRepo.getRoomWithEvent(roomId);
+    const event = await eventRepo.getEventWithRoom(roomId);
 
     if (event) {
       console.log(JSON.stringify(event));
@@ -342,7 +342,7 @@ export class RoomService {
     }
 
     if (room && this._roomRepo.isPersistent()) {
-      const event = await eventRepo.getRoomWithEvent(roomId);
+      const event = await eventRepo.getEventWithRoom(roomId);
 
       return {
         room,

--- a/app/(server)/api/rooms/[roomID]/route.ts
+++ b/app/(server)/api/rooms/[roomID]/route.ts
@@ -13,9 +13,9 @@ export async function GET(
 ) {
   const roomID = params.roomID;
   try {
-    const { room, event } = await roomService.joinRoom(roomID);
+    const res = await roomService.joinRoom(roomID);
 
-    if (!room) {
+    if (!res.room) {
       return NextResponse.json({
         code: 404,
         message: 'Room not found',
@@ -26,10 +26,7 @@ export async function GET(
       {
         code: 200,
         message: 'Room found',
-        data: room,
-        meta: {
-          event: event,
-        },
+        data: res,
       },
       { status: 200 }
     );

--- a/app/_shared/types/room.d.ts
+++ b/app/_shared/types/room.d.ts
@@ -12,9 +12,9 @@ export declare namespace RoomType {
 
   type CreateGetRoomResponse = FetcherResponse & {
     message: string;
-    data: Room;
-    meta?: {
-      event?: EventType.Event | null;
+    data: {
+      room: Room;
+      event: EventType.Event;
     };
   };
 


### PR DESCRIPTION
This PR Update the Room Middleware allowing Event Room for `scheduled meeting` to be joinable without clientID