### PR TITLE
Fix/join room endpoint cahched

### DIFF
--- a/app/_shared/middlewares/room.ts
+++ b/app/_shared/middlewares/room.ts
@@ -91,7 +91,8 @@ export function withRoomMiddleware(middleware: NextMiddleware) {
       try {
         const roomResponse: RoomType.GetRoomResponse =
           await InternalApiFetcher.get(`/api/rooms/${roomID}`, {
-            cache: 'no-store',
+            cache: 'no-cache',
+            next: { revalidate: 0 },
           });
         roomData = roomResponse.data;
         eventData = roomResponse.data.event;

--- a/app/_shared/middlewares/room.ts
+++ b/app/_shared/middlewares/room.ts
@@ -89,10 +89,10 @@ export function withRoomMiddleware(middleware: NextMiddleware) {
       };
 
       try {
-        const roomResponse: RoomType.GetRoomResponse
-         = await InternalApiFetcher.get(`/api/rooms/${roomID}`, {
-          cache: 'no-cache',
-        });
+        const roomResponse: RoomType.GetRoomResponse =
+          await InternalApiFetcher.get(`/api/rooms/${roomID}`, {
+            cache: 'no-store',
+          });
         roomData = roomResponse.data;
         eventData = roomResponse.data.event;
       } catch (error) {


### PR DESCRIPTION
This PR fixes the `Room Middleware` which was not fetching join room endpoint and instead uses cached response instead

previously `no-cache` was a valid value, but according to the latest documentation `no-store` would be the valid value

where it states 

> `no-store` :  Next.js fetches the resource from the remote server on every request without looking in the cache, and it will not update the cache with the downloaded resource.

just in case, I also added options to remove cache lifetime, by adding the folowing code to the fetch options 

```
{ next: { revalidate:  0 }
```

[NextJS Fetch Documentation](https://nextjs.org/docs/app/api-reference/functions/fetch#optionscache)