### PR TITLE
Fix/remove client id scheduled meeting

### DIFF
--- a/app/(server)/_features/scheduled-meeting/service.ts
+++ b/app/(server)/_features/scheduled-meeting/service.ts
@@ -100,7 +100,7 @@ class ScheduledMeetingService {
     );
 
     // Send Email to Host
-    const joinRoomURL = `${BASE_URL}/rooms/${event.roomId}?clientID=${hostParticipant.clientID}`;
+    const joinRoomURL = `${BASE_URL}/rooms/${event.roomId}`;
 
     const description = generateScheduledMeetingDescription({
       startTime: event.startTime,
@@ -134,9 +134,6 @@ class ScheduledMeetingService {
         },
         host: {
           name: host.name,
-        },
-        participant: {
-          clientId: hostParticipant.clientID,
         },
       })
     );
@@ -269,9 +266,6 @@ class ScheduledMeetingService {
           },
           host: {
             name: host.name,
-          },
-          participant: {
-            clientId: participant.clientID,
           },
         })
       );

--- a/app/(server)/api/events/[slugOrId]/client/route.ts
+++ b/app/(server)/api/events/[slugOrId]/client/route.ts
@@ -1,4 +1,3 @@
-import { selectParticipant } from '@/(server)/_features/event/schema';
 import { EventParticipant } from '@/(server)/_features/event/service';
 import { getCurrentAuthenticated } from '@/(server)/_shared/utils/get-current-authenticated';
 import { eventService } from '@/(server)/api/_index';

--- a/app/_shared/middlewares/room.ts
+++ b/app/_shared/middlewares/room.ts
@@ -91,10 +91,6 @@ export function withRoomMiddleware(middleware: NextMiddleware) {
         const roomResponse: RoomType.GetRoomResponse =
           await InternalApiFetcher.get(`/api/rooms/${roomID}`, {
             cache: 'no-cache',
-          });
-        const roomResponse: RoomType.GetRoomResponse =
-          await InternalApiFetcher.get(`/api/rooms/${roomID}`, {
-            cache: 'no-cache',
             next: { revalidate: 0 },
           });
         roomData = roomResponse.data;

--- a/emails/event/EventScheduleMeeting.tsx
+++ b/emails/event/EventScheduleMeeting.tsx
@@ -30,8 +30,6 @@ type ScheduledMeetingMeta = {
 
 export default function EmailScheduledMeeting({
   event = dummyEvent,
-  host
-  participant = {clientId: ""},
   host = {
     name : ""
   }

--- a/emails/event/EventScheduleMeeting.tsx
+++ b/emails/event/EventScheduleMeeting.tsx
@@ -1,5 +1,4 @@
 import { Html, Tailwind, Body, Img, Head, Font, Container, Button, Row, Column } from '@react-email/components';
-import { EventType } from '@/_shared/types/event';
 import * as React from "react";
 
 
@@ -27,14 +26,10 @@ type ScheduledMeetingMeta = {
   host: {
     name: string;
   };
-  participant: {
-    clientId: string;
-  }
 }
 
 export default function EmailScheduledMeeting({
   event = dummyEvent,
-  participant,
   host
 }: ScheduledMeetingMeta) {
   const startDate = Intl.DateTimeFormat('en-GB', {
@@ -142,7 +137,7 @@ export default function EmailScheduledMeeting({
 
               <Button
                 className="rounded-md bg-red-800 py-2 text-[14px] antialiase text-zinc-100 w-full text-center justify-center mt-2"
-                href={`${APP_ORIGIN}/rooms/${event.roomID}?clientID=${participant.clientId}`}>
+                href={`${APP_ORIGIN}/rooms/${event.roomID}`}>
                 Join Meeting
               </Button>
 


### PR DESCRIPTION
This PR : remove request to fetch clientID to events for `meetings` and will create a request a new clientID instead