### PR TITLE
Fix/client id name redirection

### DIFF
--- a/app/(server)/_features/room/service.ts
+++ b/app/(server)/_features/room/service.ts
@@ -130,6 +130,8 @@ export class RoomService {
             400
           );
         }
+
+        clientName = participant.name;
       }
     }
 


### PR DESCRIPTION
This PR fixes the following :
* When joining a webinar room with ClientID it didn't set the Client Name with the User Name
* When joining a webinar room with invalid ClientID it didn't redirect the user 